### PR TITLE
Update deploy.sh

### DIFF
--- a/e2e_samples/parking_sensors/deploy.sh
+++ b/e2e_samples/parking_sensors/deploy.sh
@@ -73,9 +73,7 @@ done
 
 # By default, set all KeyVault permission to deployer
 # Retrieve KeyVault User Id
-userId=$(az account show --output json | jq -r '.user.name')
-kvOwnerObjectId=$(az ad user show --id $userId \
-    --output json | jq -r '.objectId')
+kvOwnerObjectId=$(az ad signed-in-user show --output json | jq -r '.objectId')
 
 
 ###################


### PR DESCRIPTION
I was having issues with this line of the deploy script. The original line of, 'userId=$(az account show --output json | jq -r '.user.name')' would give me a user.name of 'user@contosco.com'. So using that with the following line:
# kvOwnerObjectId=$(az ad user show --id $userId \
#    --output json | jq -r '.objectId')
Always resulted in an error indicating it couldn't find the resource. The command 'az ad user show --id' expects an ObjectId or the user principle name. Unless we need to capture the actual username in the userId variable, I'm suggesting using the proposed line of:
kvOwnerObjectId=$(az ad signed-in-user show --output json | jq -r '.objectId')