### PR TITLE
Fixing python unit test

### DIFF
--- a/e2e_samples/parking_sensors/devops/azure-pipelines-ci-qa-python.yml
+++ b/e2e_samples/parking_sensors/devops/azure-pipelines-ci-qa-python.yml
@@ -25,6 +25,6 @@ steps:
   workingDirectory: $(pythonWorkingDir)
   displayName: 'Install requirements'
 
-- script: make lint && make tests 
+- script: make lint && make test
   workingDirectory: $(pythonWorkingDir)
   displayName: 'Run lint tests'

--- a/e2e_samples/parking_sensors/src/ddo_transform/tests/test_standardize.py
+++ b/e2e_samples/parking_sensors/src/ddo_transform/tests/test_standardize.py
@@ -4,10 +4,12 @@
 """Tests for `ddo_transform` package."""
 
 import os
+import sys
 import pytest
 import datetime
 from pyspark.sql.functions import isnull
 
+sys.path.append('../ddo_transform/')
 from ddo_transform import standardize
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/e2e_samples/parking_sensors/src/ddo_transform/tests/test_transform.py
+++ b/e2e_samples/parking_sensors/src/ddo_transform/tests/test_transform.py
@@ -4,9 +4,11 @@
 """Tests for `ddo_transform` package."""
 
 import os
+import sys
 import pytest
 import datetime
 
+sys.path.append('../ddo_transform/')
 from ddo_transform import transform
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
There were two issues with the python unit tests:

1.  Wrong makefile command in CI QA python pipeline
2. The pytest was not able to find the library so I added the sys path (quickfix; any better idea for it?)