### PR TITLE
Lace/bugfix 71 wrong databricks url

### DIFF
--- a/e2e_samples/parking_sensors/adf/linkedService/Ls_AzureDatabricks_01.json
+++ b/e2e_samples/parking_sensors/adf/linkedService/Ls_AzureDatabricks_01.json
@@ -19,7 +19,7 @@
 			"newClusterSparkEnvVars": {
 				"PYSPARK_PYTHON": "/databricks/python3/bin/python3"
 			},
-			"newClusterVersion": "5.5.x-scala2.11"
+			"newClusterVersion": "7.3.x-scala2.12"
 		}
 	}
 }

--- a/e2e_samples/parking_sensors/databricks/config/cluster.config.json
+++ b/e2e_samples/parking_sensors/databricks/config/cluster.config.json
@@ -1,7 +1,7 @@
 {
     "cluster_name": "ddo_cluster",
     "autoscale": { "min_workers": 1, "max_workers": 2 },
-    "spark_version": "6.6.x-scala2.11",
+    "spark_version": "7.3.x-scala2.12",
     "autotermination_minutes": 30,
     "node_type_id": "Standard_DS3_v2",
     "driver_node_type_id": "Standard_DS3_v2",

--- a/e2e_samples/parking_sensors/infrastructure/azuredeploy.json
+++ b/e2e_samples/parking_sensors/infrastructure/azuredeploy.json
@@ -304,7 +304,7 @@
             "type": "string",
             "value": "[resourceId('Microsoft.Databricks/workspaces', parameters('databricks_workspace_name'))]"
         },
-        "workspace": {
+        "databricks_workspace": {
             "type": "object",
             "value": "[reference(resourceId('Microsoft.Databricks/workspaces', parameters('databricks_workspace_name')))]"
         },

--- a/e2e_samples/parking_sensors/infrastructure/azuredeploy.json
+++ b/e2e_samples/parking_sensors/infrastructure/azuredeploy.json
@@ -304,6 +304,10 @@
             "type": "string",
             "value": "[resourceId('Microsoft.Databricks/workspaces', parameters('databricks_workspace_name'))]"
         },
+        "workspace": {
+            "type": "object",
+            "value": "[reference(resourceId('Microsoft.Databricks/workspaces', parameters('databricks_workspace_name')))]"
+        },
         "keyvault_name": {
             "value": "[parameters('keyvault_name')]",
             "type": "string"

--- a/e2e_samples/parking_sensors/scripts/deploy_infrastructure.sh
+++ b/e2e_samples/parking_sensors/scripts/deploy_infrastructure.sh
@@ -158,9 +158,8 @@ export APPINSIGHTS_KEY=$(az monitor app-insights component show \
 # 
 echo "Retrieving Databricks information from the deployment."
 databricks_location=$(echo $arm_output | jq -r '.properties.outputs.databricks_location.value')
-databricks_workspace_name=$(echo $arm_output | jq -r '.properties.outputs.databricks_workspace_name.value')
-databricks_workspace_id=$(echo $arm_output | jq -r '.properties.outputs.databricks_workspace_id.value')
-export DATABRICKS_HOST=https://${databricks_location}.azuredatabricks.net
+databricks_workspace_id=$(echo $arm_output | jq -r '.properties.outputs.databricks_workspace.value.workspaceId')
+export DATABRICKS_HOST=https://$(echo $arm_output | jq -r '.properties.outputs.databricks_workspace.value.workspaceUrl')
 
 # Retrieve databricks PAT token
 echo "Generating a Databricks PAT token."
@@ -197,6 +196,7 @@ mkdir -p $adfTempDir && cp -a adf/ .tmp/
 tmpfile=.tmpfile
 adfLsDir=$adfTempDir/linkedService
 jq --arg kvurl "$KV_URL" '.properties.typeProperties.baseUrl = $kvurl' $adfLsDir/Ls_KeyVault_01.json > "$tmpfile" && mv "$tmpfile" $adfLsDir/Ls_KeyVault_01.json
+jq --arg databricksWorkspaceUrl "$DATABRICKS_HOST" '.properties.typeProperties.domain = $databricksWorkspaceUrl' $adfLsDir/Ls_AzureDatabricks_01.json > "$tmpfile" && mv "$tmpfile" $adfLsDir/Ls_AzureDatabricks_01.json
 jq --arg datalakeUrl "https://$AZURE_STORAGE_ACCOUNT.dfs.core.windows.net" '.properties.typeProperties.url = $datalakeUrl' $adfLsDir/Ls_AdlsGen2_01.json > "$tmpfile" && mv "$tmpfile" $adfLsDir/Ls_AdlsGen2_01.json
 
 # Deploy ADF artifacts

--- a/e2e_samples/parking_sensors/scripts/deploy_infrastructure.sh
+++ b/e2e_samples/parking_sensors/scripts/deploy_infrastructure.sh
@@ -157,8 +157,8 @@ export APPINSIGHTS_KEY=$(az monitor app-insights component show \
 # # RETRIEVE DATABRICKS INFORMATION AND CONFIGURE WORKSPACE
 # 
 echo "Retrieving Databricks information from the deployment."
-databricks_location=$(echo $arm_output | jq -r '.properties.outputs.databricks_location.value')
-databricks_workspace_id=$(echo $arm_output | jq -r '.properties.outputs.databricks_workspace.value.workspaceId')
+# databricks_location=$(echo $arm_output | jq -r '.properties.outputs.databricks_location.value')
+databricks_workspace_id=$(echo $arm_output | jq -r '.properties.outputs.databricks_workspace_id.value')
 export DATABRICKS_HOST=https://$(echo $arm_output | jq -r '.properties.outputs.databricks_workspace.value.workspaceUrl')
 
 # Retrieve databricks PAT token
@@ -192,7 +192,7 @@ echo "Updating Data Factory LinkedService to point to newly deployed resources (
 # Create a copy of the ADF dir into a .tmp/ folder.
 adfTempDir=.tmp/adf
 mkdir -p $adfTempDir && cp -a adf/ .tmp/
-# Update LinkedServices to point to newly deployed Datalake and KeyVault
+# Update ADF LinkedServices to point to newly deployed Datalake URL, KeyVault URL, and Databricks workspace URL
 tmpfile=.tmpfile
 adfLsDir=$adfTempDir/linkedService
 jq --arg kvurl "$KV_URL" '.properties.typeProperties.baseUrl = $kvurl' $adfLsDir/Ls_KeyVault_01.json > "$tmpfile" && mv "$tmpfile" $adfLsDir/Ls_KeyVault_01.json


### PR DESCRIPTION
This PR resolves #71 .
- Updates Databricks Worksace URL to use workspace-specific from old region-based url.
- Updates ADF LinkedService to point to correct Databricks workspace URL
- Minor update to Databricks cluster version to use latest cluster