### PR TITLE
fix(destroy-script): typo on resource group

### DIFF
--- a/single_tech_samples/databricks/Cluster_Deployment/destroy.sh
+++ b/single_tech_samples/databricks/Cluster_Deployment/destroy.sh
@@ -4,7 +4,7 @@ DEPLOYMENT_PREFIX=${DEPLOYMENT_PREFIX:-}
 AZURE_SUBSCRIPTION_ID=${AZURE_SUBSCRIPTION_ID:-}
 AZURE_RESOURCE_GROUP_NAME=${AZURE_RESOURCE_GROUP_NAME:-}
 AZURE_RESOURCE_GROUP_LOCATION=${AZURE_RESOURCE_GROUP_LOCATION:-}
-DELETE_RESOURCE_GRUP=${DELETE_RESOURCE_GRUP:-}
+DELETE_RESOURCE_GROUP=${DELETE_RESOURCE_GROUP:-}
 
 if [[ -z "$DEPLOYMENT_PREFIX" ]]; then
     echo "No deployment prefix [DEPLOYMENT_PREFIX] specified."
@@ -46,9 +46,9 @@ adbWorkspaceName="${DEPLOYMENT_PREFIX}adb01"
 keyVaultName="${DEPLOYMENT_PREFIX}akv01"
 storageAccountName="${DEPLOYMENT_PREFIX}asa01"
 
-echo "Delete Resouce Group? $DELETE_RESOURCE_GRUP"
+echo "Delete Resouce Group? $DELETE_RESOURCE_GROUP"
 
-if [[ $DELETE_RESOURCE_GRUP == true ]]; then
+if [[ $DELETE_RESOURCE_GROUP == true ]]; then
     echo "Deleting resource group: $AZURE_RESOURCE_GROUP_NAME with all the resources. In 5 seconds..."
     sleep 5s
     az group delete --resource-group "$AZURE_RESOURCE_GROUP_NAME" --output none --yes


### PR DESCRIPTION
## Purpose
* Fix typo on `destroy.sh` script

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

## Validation
- create the following environment variables:
  ```bash
  export DEPLOYMENT_PREFIX=<PREFIX FOR RESOURCE NAMES>
  export AZURE_SUBSCRIPTION_ID=<SUBSCRIPTION ID TO USE>
  export AZURE_RESOURCE_GROUP_NAME=<RG NAME>
  export AZURE_RESOURCE_GROUP_LOCATION=eastus
  export DELETE_RESOURCE_GROUP=false
  ```

- ```bash
  cd Cluster_Deployment
  ./deploy.sh
  ```

- ```bash
  cd Cluster_Deployment
  ./destroy.sh
  ```

## Author pre-publish checklist:
- [ ] Added test to prove my fix is effective or new feature works
- [ ] No PII in logs
- [ ] Made corresponding changes to the documentation

## Issues Closed or Referenced

- Closes #187 