### PR TITLE
Single tech/databricks 211 default region west us

### DIFF
--- a/single_tech_samples/databricks/sample1_basic_azure_databricks_environment/databricks/workspace.parameters.json
+++ b/single_tech_samples/databricks/sample1_basic_azure_databricks_environment/databricks/workspace.parameters.json
@@ -6,7 +6,7 @@
       "value": "samplewsname"
     },
     "adbWorkspaceLocation": {
-      "value": "eastus"
+      "value": "westus"
     },
     "adbWorkspaceSkuTier": {
       "value": "standard"

--- a/single_tech_samples/databricks/sample1_basic_azure_databricks_environment/databricks/workspace.template.json
+++ b/single_tech_samples/databricks/sample1_basic_azure_databricks_environment/databricks/workspace.template.json
@@ -69,7 +69,7 @@
       "type": "string"
     },
     "databricks_location": {
-      "value": "[resourceGroup().location]",
+      "value": "[parameters('adbWorkspaceLocation')]",
       "type": "string"
     },
     "databricks_workspace_id": {

--- a/single_tech_samples/databricks/sample1_basic_azure_databricks_environment/deploy.sh
+++ b/single_tech_samples/databricks/sample1_basic_azure_databricks_environment/deploy.sh
@@ -19,7 +19,8 @@ if [[ -z "$AZURE_RESOURCE_GROUP_NAME" ]]; then
 fi
 if [[ -z "$AZURE_RESOURCE_GROUP_LOCATION" ]]; then
     echo "No Azure resource group [AZURE_RESOURCE_GROUP_LOCATION] specified."
-    exit 1
+    echo "Default location will be set to -> westus"
+    AZURE_RESOURCE_GROUP_LOCATION="westus"
 fi
 
 # Login to Azure and select the subscription

--- a/single_tech_samples/databricks/sample1_basic_azure_databricks_environment/destroy.sh
+++ b/single_tech_samples/databricks/sample1_basic_azure_databricks_environment/destroy.sh
@@ -20,7 +20,8 @@ if [[ -z "$AZURE_RESOURCE_GROUP_NAME" ]]; then
 fi
 if [[ -z "$AZURE_RESOURCE_GROUP_LOCATION" ]]; then
     echo "No Azure resource group [AZURE_RESOURCE_GROUP_LOCATION] specified."
-    exit 1
+    echo "Default location will be set to -> westus"
+    AZURE_RESOURCE_GROUP_LOCATION="westus"
 fi
 
 # Login to Azure and select the subscription

--- a/single_tech_samples/databricks/sample1_basic_azure_databricks_environment/keyvault/keyvault.parameters.json
+++ b/single_tech_samples/databricks/sample1_basic_azure_databricks_environment/keyvault/keyvault.parameters.json
@@ -9,7 +9,7 @@
       "value": "Standard"
     },
     "keyVaultLocation": {
-      "value": "eastus"
+      "value": "westus"
     },
     "enabledForDeployment": {
       "value": false

--- a/single_tech_samples/databricks/sample1_basic_azure_databricks_environment/storageaccount/storageaccount.parameters.json
+++ b/single_tech_samples/databricks/sample1_basic_azure_databricks_environment/storageaccount/storageaccount.parameters.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "storageAccountName": {
-            "value": "adbstoragetest1" 
+            "value": "adbstoragetest1"
         },
         "storageAccountSku": {
             "value": "Standard_LRS"
@@ -12,7 +12,7 @@
             "value": "Standard"
         },
         "storageAccountLocation": {
-            "value": "australiaeast" 
+            "value": "westus"
         },
         "encryptionEnabled": {
             "value": true

--- a/single_tech_samples/databricks/sample2_enterprise_azure_databricks_environment/databricks/workspace.parameters.json
+++ b/single_tech_samples/databricks/sample2_enterprise_azure_databricks_environment/databricks/workspace.parameters.json
@@ -9,7 +9,7 @@
       "value": "samplewsname"
     },
     "adbWorkspaceLocation": {
-      "value": "eastus"
+      "value": "westus"
     },
     "adbWorkspaceSkuTier": {
       "value": "standard"

--- a/single_tech_samples/databricks/sample2_enterprise_azure_databricks_environment/databricks/workspace.template.json
+++ b/single_tech_samples/databricks/sample2_enterprise_azure_databricks_environment/databricks/workspace.template.json
@@ -99,7 +99,7 @@
       "type": "string"
     },
     "databricks_location": {
-      "value": "[resourceGroup().location]",
+      "value": "[parameters('adbWorkspaceLocation')]",
       "type": "string"
     },
     "databricks_workspace_id": {

--- a/single_tech_samples/databricks/sample2_enterprise_azure_databricks_environment/destroy.sh
+++ b/single_tech_samples/databricks/sample2_enterprise_azure_databricks_environment/destroy.sh
@@ -20,7 +20,8 @@ if [[ -z "$AZURE_RESOURCE_GROUP_NAME" ]]; then
 fi
 if [[ -z "$AZURE_RESOURCE_GROUP_LOCATION" ]]; then
     echo "No Azure resource group [AZURE_RESOURCE_GROUP_LOCATION] specified."
-    exit 1
+    echo "Default location will be set to -> westus"
+    AZURE_RESOURCE_GROUP_LOCATION="westus"
 fi
 
 # Login to Azure and select the subscription

--- a/single_tech_samples/databricks/sample2_enterprise_azure_databricks_environment/example-dotenv
+++ b/single_tech_samples/databricks/sample2_enterprise_azure_databricks_environment/example-dotenv
@@ -1,5 +1,5 @@
 export DEPLOYMENT_PREFIX=lumos
 export AZURE_SUBSCRIPTION_ID=<thesubscriptionid>
 export AZURE_RESOURCE_GROUP_NAME=lumosrg
-export AZURE_RESOURCE_GROUP_LOCATION=eastus
+export AZURE_RESOURCE_GROUP_LOCATION=westus
 export DELETE_RESOURCE_GROUP=true

--- a/single_tech_samples/databricks/sample2_enterprise_azure_databricks_environment/firewall/firewall.parameters.json
+++ b/single_tech_samples/databricks/sample2_enterprise_azure_databricks_environment/firewall/firewall.parameters.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "firewalllocation": {
-            "value": "australiaeast"
+            "value": "westus"
         },
         "publicIpAddressName": {
             "value": "adbFWIP"
@@ -13,6 +13,23 @@
         },
         "vnetName": {
             "value": "adbhubVnet01"
+        },
+        "firewallWebappDestinationAddresses": {
+            "value": [
+                "40.118.174.12/32",
+                "20.42.129.160/32"
+            ]
+        },
+        "firewallControlPlaneDestinationAddresses": {
+            "value": [
+                "40.83.178.242/32",
+                "20.42.129.161/32"
+            ]
+        },
+        "firewallSccRelayDestinationFqdns": {
+            "value": [
+                "tunnel.westus.azuredatabricks.net"
+            ]
         }
     }
 }

--- a/single_tech_samples/databricks/sample2_enterprise_azure_databricks_environment/firewall/firewall.template.json
+++ b/single_tech_samples/databricks/sample2_enterprise_azure_databricks_environment/firewall/firewall.template.json
@@ -4,7 +4,7 @@
     "parameters": {
         "firewalllocation": {
             "type": "string",
-            "defaultValue": "australiaeast",
+            "defaultValue": "[resourceGroup().location]",
             "metadata": {
                 "description": "Azure datacentre Location to deploy the Firewall and IP Address"
             }
@@ -35,6 +35,18 @@
             "metadata": {
                 "description": "Name of the vnet associated witht he Firewall"
             }
+        },
+        "firewallWebappDestinationAddresses": {
+            "type": "array",
+            "defaultValue": []
+        },
+        "firewallControlPlaneDestinationAddresses": {
+            "type": "array",
+            "defaultValue": []
+        },
+        "firewallSccRelayDestinationFqdns": {
+            "type": "array",
+            "defaultValue": []
         }
     },
     "variables": {
@@ -78,7 +90,7 @@
                 ],
                 "sku": {
                     "tier": "[parameters('firewallSKU')]"
-                },                
+                },
                 "threatIntelMode": "Alert",
                 "additionalProperties": {
                     "Network.DNS.EnableProxy": "true"
@@ -100,9 +112,7 @@
                                     "sourceAddresses": [
                                         "*"
                                     ],
-                                    "destinationAddresses": [
-                                        "13.75.218.172/32"
-                                    ],
+                                    "destinationAddresses": "[parameters('firewallWebappDestinationAddresses')]",
                                     "sourceIpGroups": [],
                                     "destinationIpGroups": [],
                                     "destinationFqdns": [],
@@ -118,9 +128,7 @@
                                     "sourceAddresses": [
                                         "*"
                                     ],
-                                    "destinationAddresses": [
-                                        "13.70.105.50/32"
-                                    ],
+                                    "destinationAddresses": "[parameters('firewallControlPlaneDestinationAddresses')]",
                                     "sourceIpGroups": [],
                                     "destinationIpGroups": [],
                                     "destinationFqdns": [],
@@ -157,9 +165,7 @@
                                     "destinationAddresses": [],
                                     "sourceIpGroups": [],
                                     "destinationIpGroups": [],
-                                    "destinationFqdns": [
-                                        "tunnel.australiaeast.azuredatabricks.net"
-                                    ],
+                                    "destinationFqdns": "[parameters('firewallSccRelayDestinationFqdns')]",
                                     "destinationPorts": [
                                         "*"
                                     ]

--- a/single_tech_samples/databricks/sample2_enterprise_azure_databricks_environment/keyvault/keyvault.parameters.json
+++ b/single_tech_samples/databricks/sample2_enterprise_azure_databricks_environment/keyvault/keyvault.parameters.json
@@ -9,7 +9,7 @@
       "value": "Standard"
     },
     "keyVaultLocation": {
-      "value": "eastus"
+      "value": "westus"
     },
     "enabledForDeployment": {
       "value": false

--- a/single_tech_samples/databricks/sample2_enterprise_azure_databricks_environment/keyvault/privateendpoint.parameters.json
+++ b/single_tech_samples/databricks/sample2_enterprise_azure_databricks_environment/keyvault/privateendpoint.parameters.json
@@ -16,6 +16,9 @@
     },
     "vnetName": {
       "value": "juan2vnet01"
+    },
+    "privateLinkLocation": {
+      "value": "westus"
     }
   }
 }

--- a/single_tech_samples/databricks/sample2_enterprise_azure_databricks_environment/keyvault/privateendpoint.template.json
+++ b/single_tech_samples/databricks/sample2_enterprise_azure_databricks_environment/keyvault/privateendpoint.template.json
@@ -31,6 +31,13 @@
       "metadata": {
         "description": "Privatelink subnet Id"
       }
+    },
+    "privateLinkLocation": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Privatelink subnet Id"
+      }
     }
   },
   "variables": {
@@ -42,7 +49,7 @@
       "apiVersion": "2020-03-01",
       "name": "[variables('keyvaultPrivateEndpointName')]",
       "type": "Microsoft.Network/privateEndpoints",
-      "location": "[resourceGroup().Location]",
+      "location": "[parameters('privateLinkLocation')]",
       "properties": {
         "privateLinkServiceConnections": [
           {
@@ -92,13 +99,12 @@
       "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
       "apiVersion": "2020-03-01",
       "name": "[concat(variables('keyvaultPrivateEndpointName'), '/', 'default')]",
-      "location": "[resourceGroup().Location]",
+      "location": "[parameters('privateLinkLocation')]",
       "properties": {
         "privateDnsZoneConfigs": [
           {
             "name": "privatelink-vaultcore-azure-net",
             "properties": {
-              // "privateDnsZoneId": "/subscriptions/b543aa2b-f823-4d1d-8188-fed701a61253/resourceGroups/juan-rg-02/providers/Microsoft.Network/privateDnsZones/privatelink.dfs.core.windows.net"
               "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', variables('privateDnsName'))]"
             }
           }

--- a/single_tech_samples/databricks/sample2_enterprise_azure_databricks_environment/routetable/routetable.parameters.json
+++ b/single_tech_samples/databricks/sample2_enterprise_azure_databricks_environment/routetable/routetable.parameters.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "reouteTablelocation": {
-            "value": "australiaeast"
+            "value": "westus"
         },
         "routeTableName": {
             "value": "adbHubRT"

--- a/single_tech_samples/databricks/sample2_enterprise_azure_databricks_environment/routetable/routetable.template.json
+++ b/single_tech_samples/databricks/sample2_enterprise_azure_databricks_environment/routetable/routetable.template.json
@@ -4,7 +4,7 @@
     "parameters": {
         "reouteTablelocation": {
             "type": "string",
-            "defaultValue": "australiaeast",
+            "defaultValue": "[resourceGroup().location]",
             "metadata": {
                 "description": "Azure datacentre Location to deploy the Firewall and IP Address"
             }

--- a/single_tech_samples/databricks/sample2_enterprise_azure_databricks_environment/securitygroup/securitygroup.parameters.json
+++ b/single_tech_samples/databricks/sample2_enterprise_azure_databricks_environment/securitygroup/securitygroup.parameters.json
@@ -6,7 +6,7 @@
       "value": "adbnsg01"
     },
     "securityGroupLocation": {
-      "value": "eastus"
+      "value": "westus"
     }
   }
 }

--- a/single_tech_samples/databricks/sample2_enterprise_azure_databricks_environment/storageaccount/privateendpoint.parameters.json
+++ b/single_tech_samples/databricks/sample2_enterprise_azure_databricks_environment/storageaccount/privateendpoint.parameters.json
@@ -16,6 +16,9 @@
     },
     "privateLinkSubnetId": {
       "value": "/subscriptions/b543aa2b-f823-4d1d-8188-fed701a61253/resourceGroups/juan-rg-01/providers/Microsoft.Network/virtualNetworks/juanvnet01/subnets/privatelink-subnet"
+    },
+    "privateLinkLocation": {
+      "value": "westus"
     }
   }
 }

--- a/single_tech_samples/databricks/sample2_enterprise_azure_databricks_environment/storageaccount/privateendpoint.template.json
+++ b/single_tech_samples/databricks/sample2_enterprise_azure_databricks_environment/storageaccount/privateendpoint.template.json
@@ -31,6 +31,13 @@
       "metadata": {
         "description": "privatelink SubnetId"
       }
+    },
+    "privateLinkLocation": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Privatelink subnet Id"
+      }
     }
   },
   "variables": {
@@ -42,7 +49,7 @@
       "apiVersion": "2020-03-01",
       "name": "[variables('storageAccountPrivateEndpointName')]",
       "type": "Microsoft.Network/privateEndpoints",
-      "location": "[resourceGroup().Location]",
+      "location": "[parameters('privateLinkLocation')]",
       "properties": {
         "privateLinkServiceConnections": [
           {
@@ -92,7 +99,7 @@
       "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
       "apiVersion": "2020-03-01",
       "name": "[concat(variables('storageAccountPrivateEndpointName'), '/', 'default')]",
-      "location": "[resourceGroup().Location]",
+      "location": "[parameters('privateLinkLocation')]",
       "properties": {
         "privateDnsZoneConfigs": [
           {

--- a/single_tech_samples/databricks/sample2_enterprise_azure_databricks_environment/storageaccount/storageaccount.parameters.json
+++ b/single_tech_samples/databricks/sample2_enterprise_azure_databricks_environment/storageaccount/storageaccount.parameters.json
@@ -12,7 +12,7 @@
             "value": "Standard"
         },
         "storageAccountLocation": {
-            "value": "australiaeast"
+            "value": "westus"
         },
         "encryptionEnabled": {
             "value": true

--- a/single_tech_samples/databricks/sample2_enterprise_azure_databricks_environment/vnet/vnet.parameters.json
+++ b/single_tech_samples/databricks/sample2_enterprise_azure_databricks_environment/vnet/vnet.parameters.json
@@ -12,7 +12,7 @@
       "value": "adbhubvnet01"
     },
     "vnetLocation": {
-      "value": "eastus"
+      "value": "westus"
     },
     "routeTableName": {
       "value": "routeTableName"


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Update samples to use `westus` as the default region
* Update ARM templates parameters file to use `westus` as the default region
* Update ARM templates to use the resource group location as the default location

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
- [ ] Yes
- [x] No

## Validation
- open repository in the `devcontainer` in vscode

- create the following environment variables:

  ```bash
  export DEPLOYMENT_PREFIX
  export AZURE_SUBSCRIPTION_ID
  export AZURE_RESOURCE_GROUP_NAME
  export DELETE_RESOURCE_GROUP
  ```

- access `sample1_basic_azure_databricks_environment` directory and run:

  ```bash
  ./deploy.sh
  ```

- resouces deployed in westus:
  
  ![image](https://user-images.githubusercontent.com/18494471/112272728-aab4e480-8cd0-11eb-8350-f4d61ce69def.png)
  
- access `sample1_basic_azure_databricks_environment` directory and run:

  ```bash
  ./destroy.sh
  ```
  
- access `sample2_enterprise_azure_databricks_environment` directory and run:

  ```bash
  ./deploy.sh
  ```

- resouces deployed in westus:
  
  ![image](https://user-images.githubusercontent.com/18494471/112272166-eef3b500-8ccf-11eb-872c-0ee35e03b862.png)
  ![image](https://user-images.githubusercontent.com/18494471/112272473-5a3d8700-8cd0-11eb-848e-6ea909c07745.png)


- access `sample2_enterprise_azure_databricks_environment` directory and run:

  ```bash
  ./destroy.sh
  ```

## Author pre-publish checklist:
<!-- Please check check before publishing PR using "x". -->
- [ ] Added test to prove my fix is effective or new feature works
- [x] No PII in logs
- [ ] Made corresponding changes to the documentation

## References
closes #211 