### PR TITLE
[bugfix]move access policy into keyvault resource

### DIFF
--- a/e2e_samples/dataset_versioning/infra/terraform/modules/data_factory/main.tf
+++ b/e2e_samples/dataset_versioning/infra/terraform/modules/data_factory/main.tf
@@ -23,10 +23,3 @@ resource "azurerm_data_factory_linked_service_key_vault" "df_kv_ls" {
   data_factory_name   = azurerm_data_factory.data_factory.name
   key_vault_id        = var.kv_id
 }
-
-resource "azurerm_key_vault_access_policy" "principal_id" {
-  key_vault_id       = var.kv_id
-  tenant_id          = azurerm_data_factory.data_factory.identity.0.tenant_id
-  object_id          = azurerm_data_factory.data_factory.identity.0.principal_id
-  secret_permissions = ["Get"]
-}

--- a/e2e_samples/dataset_versioning/infra/terraform/modules/keyvault/locals.tf
+++ b/e2e_samples/dataset_versioning/infra/terraform/modules/keyvault/locals.tf
@@ -1,4 +1,4 @@
 locals {
-  get_permissions                       = ["Get"]
-  get_set_delete_purge_list_permissions = ["Get", "Set", "Delete", "Purge", "List", "Recover"]
+  adf_identity_secret_permissions  = ["Get"]
+  client_config_secret_permissions = ["Get", "Set", "Delete", "Purge", "List", "Recover"]
 }

--- a/e2e_samples/dataset_versioning/infra/terraform/modules/keyvault/main.tf
+++ b/e2e_samples/dataset_versioning/infra/terraform/modules/keyvault/main.tf
@@ -11,9 +11,16 @@ resource "azurerm_key_vault" "keyvault" {
   tags = {
     "iac" = "terraform"
   }
+
   access_policy {
     tenant_id          = var.client_config_current.tenant_id
     object_id          = var.client_config_current.object_id
     secret_permissions = local.get_set_delete_purge_list_permissions
+  }
+
+  access_policy {
+    tenant_id          = var.client_config_current.tenant_id
+    object_id          = var.adf_identity_id
+    secret_permissions = local.get_permissions
   }
 }

--- a/e2e_samples/dataset_versioning/infra/terraform/modules/keyvault/main.tf
+++ b/e2e_samples/dataset_versioning/infra/terraform/modules/keyvault/main.tf
@@ -11,11 +11,9 @@ resource "azurerm_key_vault" "keyvault" {
   tags = {
     "iac" = "terraform"
   }
-}
-
-resource "azurerm_key_vault_access_policy" "service_principal" {
-  key_vault_id       = azurerm_key_vault.keyvault.id
-  tenant_id          = var.client_config_current.tenant_id
-  object_id          = var.client_config_current.object_id
-  secret_permissions = local.get_set_delete_purge_list_permissions
+  access_policy {
+    tenant_id          = var.client_config_current.tenant_id
+    object_id          = var.client_config_current.object_id
+    secret_permissions = local.get_set_delete_purge_list_permissions
+  }
 }

--- a/e2e_samples/dataset_versioning/infra/terraform/modules/keyvault/main.tf
+++ b/e2e_samples/dataset_versioning/infra/terraform/modules/keyvault/main.tf
@@ -15,12 +15,12 @@ resource "azurerm_key_vault" "keyvault" {
   access_policy {
     tenant_id          = var.client_config_current.tenant_id
     object_id          = var.client_config_current.object_id
-    secret_permissions = local.get_set_delete_purge_list_permissions
+    secret_permissions = local.client_config_secret_permissions
   }
 
   access_policy {
     tenant_id          = var.client_config_current.tenant_id
     object_id          = var.adf_identity_id
-    secret_permissions = local.get_permissions
+    secret_permissions = local.adf_identity_secret_permissions
   }
 }

--- a/e2e_samples/dataset_versioning/infra/terraform/modules/keyvault/variables.tf
+++ b/e2e_samples/dataset_versioning/infra/terraform/modules/keyvault/variables.tf
@@ -29,3 +29,8 @@ variable "client_config_current" {
     object_id = string
   })
 }
+
+variable "adf_identity_id" {
+  type        = string
+  description = "ID for ADF managed identity."
+}

--- a/e2e_samples/dataset_versioning/infra/terraform/modules/service/main.tf
+++ b/e2e_samples/dataset_versioning/infra/terraform/modules/service/main.tf
@@ -11,6 +11,7 @@ module "keyvault" {
   rg_name               = var.rg_name
   location              = var.location
   client_config_current = data.azurerm_client_config.current
+  adf_identity_id       = module.azure_data_factory.adf_identity_id
 }
 
 module "azure_data_factory" {


### PR DESCRIPTION
## Purpose
Keyvault secrets created in other modules only depend on var.kv_id implicitly. If we separate the access policy to a separate resource (even within same module),  kv secrets can be created before the access policy is created. By moving the access policy into the keyvault resource block, the var.kv_id in other modules will handle the dependency and will be created after both keyvault and access policy are created.

Additionally, access policy resource and access policy block cannot be used together as the terraform docs mentioned, so I moved adf's kv access policy into access policy block as well.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
- [x] Yes
- [ ] No

## Author pre-publish checklist:
<!-- Please check check before publishing PR using "x". -->
- [ ] Added test to prove my fix is effective or new feature works
- [x] No PII in logs
- [ ] Made corresponding changes to the documentation

