### PR TITLE
Updated PR template so that it does not get reflected in checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,22 +1,20 @@
 # Type of PR
+<!-- Removed items that do not match with your change. -->
 
-- [ ] Documentation changes
-- [ ] Code changes
-- [ ] Test changes
-- [ ] CI-CD changes
-- [ ] GitHub Template changes
+- Documentation changes
+- Code changes
+- Test changes
+- CI-CD changes
+- GitHub Template changes
 
 ## Purpose
 <!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
 - ...
 
-## Does this introduce a breaking change?
-<!-- Mark one with an "x". -->
-- [ ] Yes
-- [ ] No
+## Does this introduce a breaking change? If yes, details on what can break
 
-## Author pre-publish checklist:
-<!-- Please check check before publishing PR using "x". -->
+## Author pre-publish checklist
+<!-- Please check check before publishing PR using "x". Remove a column if it's not applicable. -->
 - [ ] Added test to prove my fix is effective or new feature works
 - [ ] No PII in logs
 - [ ] Made corresponding changes to the documentation


### PR DESCRIPTION
# Type of PR
- [x] GitHub Template changes

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Better experience with pr template

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
- [x] No

## Author pre-publish checklist:
<!-- Please check check before publishing PR using "x". -->
- [x] No PII in logs


## Issues Closed or Referenced
<!-- This will automatically close the issue when the PR closes. -->
- Closes #126 
