### PR TITLE
fix: bugfix adding explicit timestamp cast

### DIFF
--- a/e2e_samples/parking_sensors/src/ddo_transform/ddo_transform/standardize.py
+++ b/e2e_samples/parking_sensors/src/ddo_transform/ddo_transform/standardize.py
@@ -43,7 +43,7 @@ def get_schema(schema_name):
 def standardize_parking_bay(parkingbay_sdf: DataFrame, load_id, loaded_on):
     t_parkingbay_sdf = (
         parkingbay_sdf
-        .withColumn("last_edit", to_timestamp("last_edit", "YYYYMMddHHmmss"))
+        .withColumn("last_edit", to_timestamp("last_edit", "yyyyMMddHHmmss"))
         .select(
             col("bay_id").cast("int").alias("bay_id"),
             "last_edit",

--- a/e2e_samples/parking_sensors/src/ddo_transform/ddo_transform/standardize.py
+++ b/e2e_samples/parking_sensors/src/ddo_transform/ddo_transform/standardize.py
@@ -53,7 +53,7 @@ def standardize_parking_bay(parkingbay_sdf: DataFrame, load_id, loaded_on):
             col("rd_seg_id").cast("int").alias("rd_seg_id"),
             "the_geom",
             lit(load_id).alias("load_id"),
-            lit(loaded_on.isoformat()).alias("loaded_on")
+            lit(loaded_on.isoformat()).cast("timestamp").alias("loaded_on")
         )
     ).cache()
     # Data Validation
@@ -73,7 +73,7 @@ def standardize_sensordata(sensordata_sdf: DataFrame, load_id, loaded_on):
             "location",
             "status",
             lit(load_id).alias("load_id"),
-            lit(loaded_on.isoformat()).alias("loaded_on")
+            lit(loaded_on.isoformat()).cast("timestamp").alias("loaded_on")
         )
     ).cache()
     # Data Validation

--- a/e2e_samples/parking_sensors/src/ddo_transform/requirements.txt
+++ b/e2e_samples/parking_sensors/src/ddo_transform/requirements.txt
@@ -1,1 +1,1 @@
-pyspark==2.4.5
+pyspark==3.1.1

--- a/e2e_samples/parking_sensors/src/ddo_transform/requirements.txt
+++ b/e2e_samples/parking_sensors/src/ddo_transform/requirements.txt
@@ -1,1 +1,1 @@
-pyspark==3.1.1
+pyspark==3.0.1


### PR DESCRIPTION
# Type of PR: 
Bugfix

## Purpose
Fixes bug in Parking Sensor example where loaded_on was not explicitly converted to timestamp. I believe old versions of Spark, this would automatically get casted but it seems newer versions require this to be explicit. Also, updated version of Spark version used in unit tests to line up with databricks cluster version.

## Does this introduce a breaking change? No.

## Author pre-publish checklist
<!-- Please check check before publishing PR using "x". Remove a column if it's not applicable. -->
- [x] Added test to prove my fix is effective or new feature works
- [x] No PII in logs
- [x] Made corresponding changes to the documentation

## Validation steps
<!-- Optional. -->
- Run integration tests as part of parking sensor solution: https://github.com/Azure-Samples/modern-data-warehouse-dataops/tree/master/e2e_samples/parking_sensors/tests/integrationtests
- Run unit tests as part of the parking sensor solution. https://github.com/Azure-Samples/modern-data-warehouse-dataops/tree/master/e2e_samples/parking_sensors/src/ddo_transform/tests