### PR TITLE
feat: add github actions linter and link checks

### DIFF
--- a/.github/workflows/credscan.yml
+++ b/.github/workflows/credscan.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
     - master
-    - single-tech/databricks
+    - single-tech/databricks-ops
 
 jobs:
   pattern_match_with_secrets:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,11 +3,11 @@ on:
   push:
     branches:
     - master
-    - single-tech/databricks
+    - single-tech/databricks-ops
   pull_request:
     branches:
     - master
-    - single-tech/databricks
+    - single-tech/databricks-ops
 
 jobs:
   markdown-link-check:

--- a/.github/workflows/yaml.yml
+++ b/.github/workflows/yaml.yml
@@ -3,11 +3,11 @@ on:
   push:
     branches:
     - master
-    - single-tech/databricks
+    - single-tech/databricks-ops
   pull_request:
     branches:
     - master
-    - single-tech/databricks
+    - single-tech/databricks-ops
 
 jobs:
   yml-lint:

--- a/e2e_samples/parking_sensors/README.md
+++ b/e2e_samples/parking_sensors/README.md
@@ -170,7 +170,7 @@ Notes:
 - This is a simplified Build and Release process for demo purposes based on [Trunk-based development practices](https://trunkbaseddevelopment.com/).
 - *A manual publish is required -- currently, this cannot be automated.
 - **The solution deployment script does not configure Approval Gates at the moment. See [Known Issues, Limitations and Workarounds](#known-issues-limitations-and-workarounds)
-- ***Many organization use dedicated Release Branches (including Microsoft) instead of deploying from `master`. See [Release Flow](https://docs.microsoft.com/en-us/azure/devops/learn/devops-at-microsoft/release-flow).
+- ***Many organization use dedicated Release Branches (including Microsoft) instead of deploying from `master`. See [Release Flow](https://devblogs.microsoft.com/devops/release-flow-how-we-do-branching-on-the-vsts-team/).
 
 More resources:
 

--- a/single_tech_samples/databricks/README.md
+++ b/single_tech_samples/databricks/README.md
@@ -1,6 +1,6 @@
 # Azure Databricks
 
-[![Generic badge](Common_Assets/Images/Status-Active.svg)](https://github.com/Azure-Samples/modern-data-warehouse-dataops/commits/single-tech/databricks/single_tech_samples/databricks)
+[![Generic badge](Common_Assets/Images/Status-Active.svg)](https://github.com/Azure-Samples/modern-data-warehouse-dataops/commits/master/single_tech_samples/databricks)
 [![GitHub license](Common_Assets/Images/MIT.svg)](https://github.com/Azure-Samples/modern-data-warehouse-dataops/blob/master/LICENSE)
 [![Open Source? Yes!](Common_Assets/Images/Open_Source.svg)](https://opensource.microsoft.com/codeofconduct/)
 


### PR DESCRIPTION
# Type of PR
- CI-CD changes

## Purpose
Adding `single-tech/databricks-ops` branch to Github Actions CI checks.

## Does this introduce a breaking change? If yes, details on what can break.
No

## Author pre-publish checklist
<!-- Please check check before publishing PR using "x". Remove a column if it's not applicable. -->
- [ ] Added test to prove my fix is effective or new feature works
- [x] No PII in logs
- [ ] Made corresponding changes to the documentation
