### PR TITLE
Ydaponte/create bicep module for synapse account and ws

### DIFF
--- a/e2e_samples/parking_sensors/README.md
+++ b/e2e_samples/parking_sensors/README.md
@@ -313,12 +313,22 @@ After a successful deployment, you should have the following resources:
 - In Azure, **three (3) Resource Groups** (one per environment) each with the following Azure resources.
   - **Data Factory** - with pipelines, datasets, linked services, triggers deployed and configured correctly per environment.
   - **Data Lake Store Gen2** and a **Service Principal (SP)** with Storage Contributor rights assigned.
+    - Main Data Lake:
+      - mdwdopsst-dev-*
+      - mdwdopsst-stg-*
+      - mdwdopsst-prod-*
+    - Default Storage for Azure Synapse workspace:
+      - mdwdopsst2-dev-*
+      - mdwdopsst2-stg-*
+      - mdwdopsst2-prod-*
   - **Databricks workspace**
     - notebooks uploaded at `/notebooks` folder in the workspace
     - SparkSQL tables created
     - ADLS Gen2 mounted at `dbfs:/mnt/datalake` using the Storage Service Principal.
     - Databricks KeyVault secrets scope created
-  - **Azure Synapse (formerly SQLDW)** - currently, empty. The Release Pipeline will deploy the SQL Database objects.
+  - **Azure Synapse SQL Dedicated Pool (formerly SQLDW)** - currently, empty. The Release Pipeline will deploy the SQL Database objects.
+  - **Azure Synapse Spark Pool** - currently, empty.
+  - **Azure Synapse Workspace** - currently, empty.
   - **Application Insights**
   - **KeyVault** with all relevant secrets stored.
 - In Azure DevOps

--- a/e2e_samples/parking_sensors/README.md
+++ b/e2e_samples/parking_sensors/README.md
@@ -89,6 +89,7 @@ It makes use of the following azure services:
 - [Azure DevOps](https://azure.microsoft.com/en-au/services/devops/)
 - [Application Insights](https://docs.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview)
 - [PowerBI](https://powerbi.microsoft.com/en-us/)
+- [Log Analytics](https://docs.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overview)
 
 For a detailed walk-through of the solution and key concepts, watch the following video recording:
 
@@ -326,8 +327,9 @@ After a successful deployment, you should have the following resources:
     - SparkSQL tables created
     - ADLS Gen2 mounted at `dbfs:/mnt/datalake` using the Storage Service Principal.
     - Databricks KeyVault secrets scope created
+  - **Log Analytics Workspace** - including a kusto query on Query explorer -> Saved queries, to verify results that will be looged on Synapse notebooks (notebooks are not deployed yet).
   - **Azure Synapse SQL Dedicated Pool (formerly SQLDW)** - currently, empty. The Release Pipeline will deploy the SQL Database objects.
-  - **Azure Synapse Spark Pool** - currently, empty.
+  - **Azure Synapse Spark Pool** - currently, empty. Configured to point the deployed Log Analytics workspace, under "Apache Spark Configuration".
   - **Azure Synapse Workspace** - currently, empty.
   - **Application Insights**
   - **KeyVault** with all relevant secrets stored.

--- a/e2e_samples/parking_sensors/infrastructure/main.bicep
+++ b/e2e_samples/parking_sensors/infrastructure/main.bicep
@@ -28,7 +28,7 @@ module databricks './modules/databricks.bicep' = {
   }
 }
 
-module storage './modules/storage.bicep' = {
+module storage './modules/storage_v2.bicep' = {
   name: 'storage_deploy_${deployment_id}'
   params: {
     project: project
@@ -39,8 +39,8 @@ module storage './modules/storage.bicep' = {
   }
 }
 
-module synapse_sql_pool './modules/synapse_sql_pool.bicep' = {
-  name: 'synapse_sql_pool_deploy_${deployment_id}'
+module synapse './modules/synapse.bicep' = {
+  name: 'synapse_deploy_${deployment_id}'
   params: {
     project: project
     env: env
@@ -76,14 +76,13 @@ module appinsights './modules/appinsights.bicep' = {
   }
 }
 
-
-
-
 output storage_account_name string = storage.outputs.storage_account_name
-output synapse_sql_pool_output object = synapse_sql_pool.outputs.synapse_sql_pool_output
+output synapse_sql_pool object = synapse.outputs.synapse_sql_pool_output
+output synapse_output_spark_pool_name string = synapse.outputs.synapseBigdataPoolName
 output databricks_output object = databricks.outputs.databricks_output
 output databricks_id string = databricks.outputs.databricks_id
 output appinsights_name string = appinsights.outputs.appinsights_name
 output keyvault_name string = keyvault.outputs.keyvault_name
 output keyvault_resource_id string = keyvault.outputs.keyvault_resource_id
 output datafactory_name string = datafactory.outputs.datafactory_name
+

--- a/e2e_samples/parking_sensors/infrastructure/main.bicep
+++ b/e2e_samples/parking_sensors/infrastructure/main.bicep
@@ -76,6 +76,16 @@ module appinsights './modules/appinsights.bicep' = {
   }
 }
 
+module loganalytics './modules/log_analytics.bicep' = {
+  name: 'log_analytics_deploy_${deployment_id}'
+  params: {
+    project: project
+    env: env
+    location: location
+    deployment_id: deployment_id
+  }
+}
+
 output storage_account_name string = storage.outputs.storage_account_name
 output synapse_sql_pool object = synapse.outputs.synapse_sql_pool_output
 output synapse_output_spark_pool_name string = synapse.outputs.synapseBigdataPoolName
@@ -85,4 +95,6 @@ output appinsights_name string = appinsights.outputs.appinsights_name
 output keyvault_name string = keyvault.outputs.keyvault_name
 output keyvault_resource_id string = keyvault.outputs.keyvault_resource_id
 output datafactory_name string = datafactory.outputs.datafactory_name
+output synapseworskspace_name string = synapse.outputs.synapseWorkspaceName
+output loganalytics_name string = loganalytics.outputs.loganalyticswsname
 

--- a/e2e_samples/parking_sensors/infrastructure/modules/log_analytics.bicep
+++ b/e2e_samples/parking_sensors/infrastructure/modules/log_analytics.bicep
@@ -1,0 +1,42 @@
+param project string
+@allowed([
+  'dev'
+  'stg'
+  'prod'
+])
+param env string
+param location string = resourceGroup().location
+param deployment_id string
+param retentionInDays int = 31
+
+
+resource loganalyticsworkspace 'Microsoft.OperationalInsights/workspaces@2020-08-01' = {
+  name: '${project}-log-${env}-${deployment_id}'
+  location: location
+  tags: {
+    DisplayName: 'Log Analytics'
+    Environment: env
+  }
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays: retentionInDays
+    features: {
+      searchVersion: 1
+      legacy: 0
+    }
+  }
+}
+
+resource workspaceName_customEvents_event_handler 'Microsoft.OperationalInsights/workspaces/savedSearches@2015-03-20' = {
+  name: '${loganalyticsworkspace.name}/CustomEvents'
+  properties: {
+    displayName: 'Custom Events Parking Sensor - Events'
+    category: 'Synapse Logging'
+    query: 'SparkLoggingEvent_CL \r\n| where logger_name_s == "ParkingSensorLogs-Standardize" \r\n| order by TimeGenerated desc' 
+    version: 1
+  }
+}
+
+output loganalyticswsname string = loganalyticsworkspace.name

--- a/e2e_samples/parking_sensors/infrastructure/modules/storage_v2.bicep
+++ b/e2e_samples/parking_sensors/infrastructure/modules/storage_v2.bicep
@@ -1,0 +1,112 @@
+param project string
+@allowed([
+  'dev'
+  'stg'
+  'prod'
+])
+param env string
+param location string = resourceGroup().location
+param deployment_id string
+param contributor_principal_id string
+
+//https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles
+var storage_blob_data_contributor = '/subscriptions/${subscription().subscriptionId}/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe'
+
+// Data Lake Storage
+resource storage 'Microsoft.Storage/storageAccounts@2021-04-01' = {
+  name: '${project}st${env}${deployment_id}'
+  location: location
+  tags: {
+    DisplayName: 'Data Lake Storage'
+    Environment: env
+  }
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    isHnsEnabled: true
+    networkAcls: {
+      bypass: 'AzureServices'
+      defaultAction: 'Allow'
+    }
+    supportsHttpsTrafficOnly: true
+    encryption: {
+      services: {
+        file: {
+          enabled: true
+        }
+        blob: {
+          enabled: true
+        }
+      }
+      keySource: 'Microsoft.Storage'
+    }
+    accessTier: 'Hot'
+  }
+}
+
+resource storage_roleassignment 'Microsoft.Authorization/roleAssignments@2020-08-01-preview' = {
+  name: guid(storage.id)
+  scope: storage
+  properties: {
+    roleDefinitionId: storage_blob_data_contributor
+    principalId: contributor_principal_id
+  }
+}
+
+// Synapse Storage
+resource storage2 'Microsoft.Storage/storageAccounts@2021-04-01' = {
+  name: '${project}st2${env}${deployment_id}'
+  location: location
+  tags: {
+    DisplayName: 'Synapse Storage'
+    Environment: env
+  }
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    isHnsEnabled: true
+    networkAcls: {
+      bypass: 'AzureServices'
+      defaultAction: 'Allow'
+    }
+    supportsHttpsTrafficOnly: true
+    encryption: {
+      services: {
+        file: {
+          enabled: true
+        }
+        blob: {
+          enabled: true
+        }
+      }
+      keySource: 'Microsoft.Storage'
+    }
+    accessTier: 'Hot'
+  }
+}
+
+resource storageFileSystem2 'Microsoft.Storage/storageAccounts/blobServices/containers@2021-04-01' = {
+  name: '${project}st2${env}${deployment_id}/default/container001'
+  properties: {
+    publicAccess: 'Container'
+  }
+  dependsOn: [
+    storage2
+  ]
+}
+
+resource storage_roleassignment2 'Microsoft.Authorization/roleAssignments@2020-08-01-preview' = {
+  name: guid(storage2.id)
+  scope: storage2
+  properties: {
+    roleDefinitionId: storage_blob_data_contributor
+    principalId: contributor_principal_id
+  }
+}
+
+output storage_account_name string = storage.name
+output storage_account_name_synapse string = storage2.name

--- a/e2e_samples/parking_sensors/infrastructure/modules/synapse.bicep
+++ b/e2e_samples/parking_sensors/infrastructure/modules/synapse.bicep
@@ -1,0 +1,179 @@
+param project string
+param env string
+param location string = resourceGroup().location
+param deployment_id string
+
+param synStorageAccount string = '${project}st2${env}${deployment_id}'
+param mainStorageAccount string = '${project}st${env}${deployment_id}'
+param synStorageFilesys string = '${synStorageAccount}/default/container001'
+param keyvault string = '${project}-kv-${env}-${deployment_id}'
+
+param sql_server_username string = 'sqlAdmin'
+@secure()
+param sql_server_password string
+
+resource synStorage 'Microsoft.Storage/storageAccounts@2021-04-01' existing = {
+  name: synStorageAccount
+}
+
+resource synFileSystem 'Microsoft.Storage/storageAccounts/blobServices/containers@2021-04-01' existing = {
+  name: synStorageFilesys
+}
+
+resource mainStorage 'Microsoft.Storage/storageAccounts@2021-04-01' existing = {
+  name: mainStorageAccount
+}
+
+resource kv 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+  name: keyvault
+}
+
+resource sql_server 'Microsoft.Sql/servers@2021-02-01-preview' = {
+  name: 'sql${env}${deployment_id}'
+  location: location
+  tags: {
+    DisplayName: 'SQL Server'
+    Environment: env
+  }
+  properties: {
+    administratorLogin: sql_server_username
+    administratorLoginPassword: sql_server_password
+  }
+  
+  resource synapse_dedicated_sql_pool 'databases@2021-02-01-preview' = {
+    name: 'syndp${env}${deployment_id}'
+    location: location
+    tags: {
+      DisplayName: 'SQL Dedicated Pool'
+      Environment: env
+    }
+    sku: {
+      name: 'DW100c'
+      tier: 'DataWarehouse'
+    }
+    properties: {
+      collation: 'SQL_Latin1_General_CP1_CI_AS'
+    }
+  }
+
+  resource firewall_rules 'firewallRules@2021-02-01-preview' = {
+    name: 'AllowAllAzureIps'
+    properties: {
+      endIpAddress: '0.0.0.0'
+      startIpAddress: '0.0.0.0'
+    }
+  }
+}
+
+resource synapseWorkspace 'Microsoft.Synapse/workspaces@2021-03-01' = {
+  name: 'syws${env}${deployment_id}'
+  tags: {
+    DisplayName: 'Synapse Workspace'
+    Environment: env
+  }
+  location: location
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    defaultDataLakeStorage: {
+      accountUrl: 'https://${synStorage.name}.dfs.${environment().suffixes.storage}'
+      filesystem: synFileSystem.name
+    }
+    publicNetworkAccess: 'Enabled'
+    managedVirtualNetwork: 'default'
+    managedResourceGroupName: '${project}-mrg-${env}-syn'
+    sqlAdministratorLogin: 'sqladminuser'
+    sqlAdministratorLoginPassword: ''
+  }
+}
+
+resource synapse_spark_sql_pool 'Microsoft.Synapse/workspaces/bigDataPools@2021-03-01' = {
+  parent: synapseWorkspace
+  name: 'synsp${env}${deployment_id}'
+  location: location
+  tags: {
+    DisplayName: 'Spark SQL Pool'
+    Environment: env
+  }
+  properties: {
+    isComputeIsolationEnabled: false
+    nodeSizeFamily: 'MemoryOptimized'
+    nodeSize: 'Small'
+    autoScale: {
+      enabled: true
+      minNodeCount: 3
+      maxNodeCount: 10
+    }
+    dynamicExecutorAllocation: {
+      enabled: true
+    }
+    autoPause: {
+      enabled: true
+      delayInMinutes: 15
+    }
+    sparkVersion: '2.4'
+    sessionLevelPackagesEnabled: true
+    customLibraries: []
+    defaultSparkLogFolder: 'logs/'
+    sparkEventsFolder: 'events/'
+  }
+}
+
+resource synapseWorkspaceFirewallRule1 'Microsoft.Synapse/workspaces/firewallrules@2021-03-01' = {
+  parent: synapseWorkspace
+  name: 'allowAll'
+  properties: {
+    startIpAddress: '0.0.0.0'
+    endIpAddress: '255.255.255.255'
+  }
+}
+
+resource roleAssignment1 'Microsoft.Authorization/roleAssignments@2020-08-01-preview' = {
+  name: guid(resourceGroup().id, resourceId('Microsoft.Storage/storageAccounts', synStorage.name))
+  properties: {
+    principalId: synapseWorkspace.identity.principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')
+    principalType: 'ServicePrincipal'
+  }
+  scope: synStorage
+}
+
+resource roleAssignment2 'Microsoft.Authorization/roleAssignments@2020-08-01-preview' = {
+  name: guid(resourceGroup().id, resourceId('Microsoft.Storage/storageAccounts', mainStorage.name))
+  properties: {
+    principalId: synapseWorkspace.identity.principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')
+    principalType: 'ServicePrincipal'
+  }
+  scope: mainStorage
+}
+
+resource kvAccessPolicy 'Microsoft.KeyVault/vaults/accessPolicies@2019-09-01' = {
+  parent: kv
+  name: 'add'
+  properties: {
+    accessPolicies: [
+      {
+        tenantId: subscription().tenantId
+        objectId: synapseWorkspace.identity.principalId
+        permissions: {
+          secrets: [
+            'get'
+            'list'
+          ]
+        }
+      }
+    ]
+  }
+}
+
+output synapseWorkspaceName string = synapseWorkspace.name
+output synapseDefaultStorageAccountName string = synStorage.name
+output synapse_sql_pool_output object = {
+  name: sql_server.name
+  username: sql_server_username
+  password: sql_server_password
+  synapse_pool_name: sql_server::synapse_dedicated_sql_pool.name
+}
+output synapseBigdataPoolName string = synapse_spark_sql_pool.name

--- a/e2e_samples/parking_sensors/scripts/deploy_azdo_variables.sh
+++ b/e2e_samples/parking_sensors/scripts/deploy_azdo_variables.sh
@@ -54,6 +54,10 @@ set -o xtrace # For debugging
 # SP_ADF_ID
 # SP_ADF_PASS
 # SP_ADF_TENANT
+# SYNAPSE_WORKSPACE_NAME
+# BIG_DATAPOOL_NAME
+# LOG_ANALYTICS_WS_ID
+# LOG_ANALYTICS_WS_KEY
 
 
 # Const
@@ -133,6 +137,18 @@ az pipelines variable-group variable create --group-id "$vargroup_secrets_id" \
     --secret "true" --name "spAdfPass" --value "$SP_ADF_PASS"
 az pipelines variable-group variable create --group-id "$vargroup_secrets_id" \
     --secret "true" --name "spAdfTenantId" --value "$SP_ADF_TENANT"
+
+# Log Analytics
+az pipelines variable-group variable create --group-id "$vargroup_secrets_id" \
+    --secret "true" --name "logAnalyticsWorkspaceId" --value "$LOG_ANALYTICS_WS_ID"
+az pipelines variable-group variable create --group-id "$vargroup_secrets_id" \
+    --secret "true" --name "logAnalyticsWorkspaceKey" --value "$LOG_ANALYTICS_WS_KEY"
+
+# Synapse
+az pipelines variable-group variable create --group-id "$vargroup_secrets_id" \
+    --secret "true" --name "synapseWorkspaceName" --value "$SYNAPSE_WORKSPACE_NAME"
+az pipelines variable-group variable create --group-id "$vargroup_secrets_id" \
+    --secret "true" --name "synapseSparkPoolName" --value "$BIG_DATAPOOL_NAME"
 
 # Delete dummy vars
 az pipelines variable-group variable delete --group-id "$vargroup_secrets_id" --name "foo" -y

--- a/e2e_samples/parking_sensors/scripts/deploy_infrastructure.sh
+++ b/e2e_samples/parking_sensors/scripts/deploy_infrastructure.sh
@@ -169,6 +169,52 @@ appinsights_key=$(az monitor app-insights component show \
 # Store in Keyvault
 az keyvault secret set --vault-name "$kv_name" --name "applicationInsightsKey" --value "$appinsights_key"
 
+####################
+# LOG ANALYTICS 
+
+echo "Retrieving Log Analytics information from the deployment."
+loganalytics_name=$(echo "$arm_output" | jq -r '.properties.outputs.loganalytics_name.value')
+loganalytics_id=$(az monitor log-analytics workspace show \
+    --workspace-name "$loganalytics_name" \
+    --resource-group "$resource_group_name" \
+    --output json |
+    jq -r '.customerId')
+loganalytics_key=$(az monitor log-analytics workspace get-shared-keys \
+    --workspace-name "$loganalytics_name" \
+    --resource-group "$resource_group_name" \
+    --output json |
+    jq -r '.primarySharedKey')
+
+# Store in Keyvault
+az keyvault secret set --vault-name "$kv_name" --name "logAnalyticsId" --value "$loganalytics_id"
+az keyvault secret set --vault-name "$kv_name" --name "logAnalyticsKey" --value "$loganalytics_key"
+
+####################
+# SYNAPSE ANALYTICS
+
+echo "Retrieving Synapse Analytics information from the deployment."
+synapseworkspace_name=$(echo "$arm_output" | jq -r '.properties.outputs.synapseworskspace_name.value')
+synapse_dev_endpoint=$(az synapse workspace show \
+    --name "$synapseworkspace_name" \
+    --resource-group "$resource_group_name" \
+    --output json |
+    jq -r '.connectivityEndpoints | .dev')
+
+synapse_sparkpool_name=$(echo "$arm_output" | jq -r '.properties.outputs.synapse_output_spark_pool_name.value')
+
+# Store in Keyvault
+az keyvault secret set --vault-name "$kv_name" --name "synapseWorkspaceName" --value "$synapseworkspace_name"
+az keyvault secret set --vault-name "$kv_name" --name "synapseDevEndpoint" --value "$synapse_dev_endpoint"
+az keyvault secret set --vault-name "$kv_name" --name "synapseSparkPoolName" --value "$synapse_sparkpool_name"
+
+# Deploy Synapse artifacts
+AZURE_SUBSCRIPTION_ID=$AZURE_SUBSCRIPTION_ID \
+RESOURCE_GROUP_NAME=$resource_group_name \
+SYNAPSE_WORKSPACE_NAME=$synapseworkspace_name \
+BIG_DATAPOOL_NAME=$synapse_sparkpool_name \
+LOG_ANALYTICS_WS_ID=$loganalytics_id \
+LOG_ANALYTICS_WS_KEY=$loganalytics_key \
+    bash -c "./scripts/deploy_synapse_artifacts.sh"
 
 # ###########################
 # # RETRIEVE DATABRICKS INFORMATION AND CONFIGURE WORKSPACE
@@ -293,6 +339,10 @@ DATAFACTORY_NAME=$datafactory_name \
 SP_ADF_ID=$sp_adf_id \
 SP_ADF_PASS=$sp_adf_pass \
 SP_ADF_TENANT=$sp_adf_tenant \
+SYNAPSE_WORKSPACE_NAME=$synapseworkspace_name \
+BIG_DATAPOOL_NAME=$synapse_sparkpool_name \
+LOG_ANALYTICS_WS_ID=$loganalytics_id \
+LOG_ANALYTICS_WS_KEY=$loganalytics_key \
     bash -c "./scripts/deploy_azdo_variables.sh"
 
 
@@ -321,6 +371,8 @@ DATABRICKS_TOKEN=${databricks_token}
 DATAFACTORY_NAME=${datafactory_name}
 APPINSIGHTS_KEY=${appinsights_key}
 KV_URL=${kv_dns_name}
+LOG_ANALYTICS_WS_ID=${loganalytics_id}
+SYNAPSE_WORKSPACE_NAME=${synapseworkspace_name}
 
 EOF
 echo "Completed deploying Azure resources $resource_group_name ($ENV_NAME)"

--- a/e2e_samples/parking_sensors/scripts/deploy_synapse_artifacts.sh
+++ b/e2e_samples/parking_sensors/scripts/deploy_synapse_artifacts.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Access granted under MIT Open Source License: https://en.wikipedia.org/wiki/MIT_License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation 
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, # and/or sell copies of the Software, 
+# and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions 
+# of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED 
+# TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+# CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+# DEALINGS IN THE SOFTWARE.
+
+
+#######################################################
+# Deploys ADF artifacts
+#
+# Prerequisites:
+# - User is logged in to the azure cli
+# - Correct Azure subscription is selected
+#######################################################
+
+set -o errexit
+set -o pipefail
+set -o nounset
+set -o xtrace # For debugging
+
+###################
+# REQUIRED ENV VARIABLES:
+#
+# AZURE_SUBSCRIPTION_ID
+# RESOURCE_GROUP_NAME
+# SYNAPSE_WORKSPACE_NAME
+# BIG_DATAPOOL_NAME
+# LOG_ANALYTICS_WS_ID
+# LOG_ANALYTICS_WS_KEY
+
+# Consts
+apiVersion="2021-03-01&force=true"
+baseUrl="https://management.azure.com/subscriptions/${AZURE_SUBSCRIPTION_ID}"
+synapseWorkspaceBaseUrl="$baseUrl/resourceGroups/${RESOURCE_GROUP_NAME}/providers/Microsoft.Synapse/workspaces/${SYNAPSE_WORKSPACE_NAME}"
+echo $synapseWorkspaceBaseUrl
+
+synapse_ws_location=$(az group show \
+    --name "${RESOURCE_GROUP_NAME}" \
+    --output json |
+    jq -r '.location')
+synapse_spark_config_body="{\"location\": \" $synapse_ws_location \", \"properties\": { \"sparkVersion\": \"2.4\", \"nodeCount\": 10, \"nodeSize\": \"Small\", \"nodeSizeFamily\": \"MemoryOptimized\", \"sparkConfigProperties\": {\"configurationType\": 0, \"filename\": \"spark_loganalytics_conf.txt\", \"content\": \"spark.synapse.logAnalytics.enabled true\r\nspark.synapse.logAnalytics.workspaceId ${LOG_ANALYTICS_WS_ID}\r\nspark.synapse.logAnalytics.secret ${LOG_ANALYTICS_WS_KEY}\"}}}"
+echo $synapse_spark_config_body
+
+uploadSynapseSparkConfiguration () {
+    declare name=$1
+    echo "Uploading Spark Configuration: $name"
+    synapseBigDataPoolUri="${synapseWorkspaceBaseUrl}/bigDataPools/${BIG_DATAPOOL_NAME}?api-version=${apiVersion}"
+    az rest --method put --headers "Content-Type=application/json" --uri "$synapseBigDataPoolUri" --body "$synapse_spark_config_body"
+}
+
+uploadSynapseSparkConfiguration "Log Analytics"


### PR DESCRIPTION
# Type of PR
- Documentation changes
- Code changes

## Purpose
- Adds the deployment of a Synapse workspace and a Synapse Spark Pool as a baseline to port the parking sensor sample to synapse

## Does this introduce a breaking change? If yes, details on what can break
On the main.bicep file I'm referencing to a storage_v2.bicep module instead of the previous storage.bicep version.

## Author pre-publish checklist
- [ ] Added test to prove my fix is effective or new feature works
- [ X] No PII in logs
- [ X] Made corresponding changes to the documentation

## Validation steps
- Deployed the e2e sample with the changes, deployment was successful

## Issues Closed or Referenced
- Closes #385 

