### PR TITLE
ConfigurationType is invalid property in bigdata pools

### DIFF
--- a/e2e_samples/parking_sensors/scripts/deploy_synapse_artifacts.sh
+++ b/e2e_samples/parking_sensors/scripts/deploy_synapse_artifacts.sh
@@ -119,7 +119,6 @@ uploadSynapseArtifactsToSparkPool(){
         \"sessionLevelPackagesEnabled\": true,
         ${customLibraryList}
         \"sparkConfigProperties\": {
-            \"configurationType\": \"File\",
             \"filename\": \"spark_loganalytics_conf.txt\",
             \"content\": \"spark.synapse.logAnalytics.enabled true\r\nspark.synapse.logAnalytics.workspaceId ${LOG_ANALYTICS_WS_ID}\r\nspark.synapse.logAnalytics.secret ${LOG_ANALYTICS_WS_KEY}\"
         },


### PR DESCRIPTION
ConfigurationType is invalid property in bigdata pools
https://docs.microsoft.com/ja-jp/rest/api/synapse/big-data-pools/create-or-update#libraryrequirements

I have confirmed in my deployment script that this property causes an error.

# Type of PR
<!-- Removed items that do not match with your change. -->

- Code changes


## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- In the process of deploying the infrastructure, I found a wrong property that caused an error, so I fixed it.

## Does this introduce a breaking change? If yes, details on what can break

## Author pre-publish checklist
<!-- Please check check before publishing PR using "x". Remove a column if it's not applicable. -->
- [ ] Added test to prove my fix is effective or new feature works
- [x] No PII in logs
- [ ] Made corresponding changes to the documentation

## Validation steps
<!-- Optional. -->
- ...

## Issues Closed or Referenced
<!-- This will automatically close the issue when the PR closes. -->
- Closes #issue_number
<!-- this references the issue but does not close with PR. -->
- References #issue_number
