### PR TITLE
replace azure sqldw with new dedicated sql pool in CD pipeline

### DIFF
--- a/e2e_samples/parking_sensors_synapse/devops/azure-pipelines-cd-release.yml
+++ b/e2e_samples/parking_sensors_synapse/devops/azure-pipelines-cd-release.yml
@@ -31,7 +31,7 @@ stages:
   - template: templates/jobs/deploy-databricks-job.yml
     parameters:
       environmentName: 'DEV'
-  - template: templates/jobs/deploy-azuresqldb-job.yml
+  - template: templates/jobs/deploy-dedicated-sql-pool-job.yml
     parameters:
       environmentName: 'DEV'
       serviceConnection: 'mdwdops-serviceconnection-dev'
@@ -45,7 +45,7 @@ stages:
   - template: templates/jobs/deploy-databricks-job.yml
     parameters:
       environmentName: 'STG'
-  - template: templates/jobs/deploy-azuresqldb-job.yml
+  - template: templates/jobs/deploy-dedicated-sql-pool-job.yml
     parameters:
       environmentName: 'STG'
       serviceConnection: 'mdwdops-serviceconnection-stg'
@@ -65,7 +65,7 @@ stages:
   - template: templates/jobs/deploy-databricks-job.yml
     parameters:
       environmentName: 'PROD'
-  - template: templates/jobs/deploy-azuresqldb-job.yml
+  - template: templates/jobs/deploy-dedicated-sql-pool-job.yml
     parameters:
       environmentName: 'PROD'
       serviceConnection: 'mdwdops-serviceconnection-prod'

--- a/e2e_samples/parking_sensors_synapse/devops/templates/jobs/deploy-dedicated-sql-pool-job.yml
+++ b/e2e_samples/parking_sensors_synapse/devops/templates/jobs/deploy-dedicated-sql-pool-job.yml
@@ -5,8 +5,8 @@ parameters:
   type: string
 
 jobs:
-- deployment: deploy_azuresqldw
-  displayName: 'Deploy to AzureSQLDW'
+- deployment: deploy_dedicated_sql_pool
+  displayName: 'Deploy to synapse dedicated sql pool'
   pool:
     vmImage: 'windows-latest'
   variables:
@@ -21,11 +21,11 @@ jobs:
           inputs:
             azureSubscription: ${{ parameters.serviceConnection }}
             AuthenticationType: 'server'
-            ServerName: $(sqlsrvrName).database.windows.net
+            ServerName: $(sqlsrvrName).sql.azuresynapse.net
             DatabaseName: $(sqlDwDatabaseName)
             SqlUsername: '$(sqlsrvrUsername)'
             SqlPassword: '$(sqlsrvrPassword)'
             deployType: 'DacpacTask'
             DacpacFile: '$(Pipeline.Workspace)/ciartifacts/sql_dw_dacpac/$(sqlProjName).dacpac'
             AdditionalArguments: '/Variables:ADLSLocation=abfss://datalake@$(datalakeAccountName).dfs.core.windows.net /Variables:ADLSCredentialKey=$(datalakeKey)'
-          displayName: 'Azure SQL Dacpac'
+          displayName: 'Deploy DACPAC to synapse dedicated sql pool'

--- a/e2e_samples/parking_sensors_synapse/docs/ADRs/001_parking_sensor_synapse.md
+++ b/e2e_samples/parking_sensors_synapse/docs/ADRs/001_parking_sensor_synapse.md
@@ -34,7 +34,7 @@ Run the existing `./deploy.sh` and prompt for choice of `databricks` or `synapse
   - `devops` - AzDO job templates and pipelines
     - `azure-pipelines-ci-qa-sql.yml` - Runs SQL DACPAC build as part of PR.
     - `azure-pipelines-ci-qa-python.yml` - Run python package unit tests as part of PR.
-    - `deploy-azuresqldb-job.yml` - template to deploy SQL DACPAC
+    - `deploy-dedicated-sql-pool-job.yml` - template to deploy SQL DACPAC
     - *Partly* `integration-tests-job.yml` - template to run integration tests, calls pytest. Environment variables passed to pytest will differ between Synapse and Databricks.
   - `sql` - SSDT Visual Studio Project that creates the SQL DACPAC
   - `src/ddo_transform` - Python package source code that produces the wheel file


### PR DESCRIPTION
# Type of PR
<!-- Removed items that do not match with your change. -->

- Documentation changes
- Code changes
- CI-CD changes

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- This PR fixes the CD pipelines to deploy to the new dedicated sql pool endpoint instead of the old sql dw.
- Also changed some namings in the CD pipelines from the old sql dw to dedicated sql pool (new)

## Does this introduce a breaking change? If yes, details on what can break
Yes, this may break until bicep replaces the old sql dw with the new dedicated sql pool.

## Author pre-publish checklist.
<!-- Please check check before publishing PR using "x". Remove a column if it's not applicable. -->
- [ ] Added test to prove my fix is effective or new feature works
- [ ] No PII in logs
- [ ] Made corresponding changes to the documentation

## Issues Closed or Referenced
<!-- This will automatically close the issue when the PR closes. -->
- Closes #397 

