### PR TITLE
feat: Utility function to solve for deploy errors around SP not ready for use

### DIFF
--- a/e2e_samples/parking_sensors_synapse/scripts/common.sh
+++ b/e2e_samples/parking_sensors_synapse/scripts/common.sh
@@ -35,7 +35,7 @@ print_style () {
 
 
 # There is a delay between creating a service principal and when it is ready for use.
-# This helper function to blocks till Service Principal is ready for use.
+# This helper function blocks deployment till Service Principal is ready for use.
 # Usage: wait_service_principal_creation <SERVICE_PRINCIPAL_APP_ID>
 wait_service_principal_creation () {
     local sp_app_id=$1

--- a/e2e_samples/parking_sensors_synapse/scripts/common.sh
+++ b/e2e_samples/parking_sensors_synapse/scripts/common.sh
@@ -34,6 +34,43 @@ print_style () {
 }
 
 
+
+
+# Retry a command up to a specific numer of times until it exits successfully,
+# with exponential back off.
+#
+#  $ retry 5 echo Hello
+#  Hello
+#
+#  $ retry 5 false
+#  Retry 1/5 exited 1, retrying in 1 seconds...
+#  Retry 2/5 exited 1, retrying in 2 seconds...
+#  Retry 3/5 exited 1, retrying in 4 seconds...
+#  Retry 4/5 exited 1, retrying in 8 seconds...
+#  Retry 5/5 exited 1, no more retries left.
+#  
+# source; https://gist.github.com/sj26/88e1c6584397bb7c13bd11108a579746
+function retry {
+  local retries=$1
+  shift
+
+  local count=0
+  until "$@"; do
+    exit=$?
+    wait=$((2 ** count))
+    count=$((count + 1))
+    if [ $count -lt "$retries" ]; then
+      echo "Retry $count/$retries exited $exit, retrying in $wait seconds..."
+      sleep $wait
+    else
+      echo "Retry $count/$retries exited $exit, no more retries left."
+      return $exit
+    fi
+  done
+  return 0
+}
+
+
 # There is a delay between creating a service principal and when it is ready for use.
 # This helper function blocks deployment till Service Principal is ready for use.
 # Usage: wait_service_principal_creation <SERVICE_PRINCIPAL_APP_ID>
@@ -41,7 +78,9 @@ wait_service_principal_creation () {
     local sp_app_id=$1
     until az ad sp list --show-mine --query "[].appId" -o tsv | grep "$sp_app_id"
     do
-        echo "waiting for sp to create..."
+        echo "waiting for service principal to finish creating..."
         sleep 10s
     done
+    # Now, try to retrieve it
+    retry 10 az ad sp show --id "$sp_app_id" --query "objectId"
 }

--- a/e2e_samples/parking_sensors_synapse/scripts/common.sh
+++ b/e2e_samples/parking_sensors_synapse/scripts/common.sh
@@ -32,3 +32,16 @@ print_style () {
 
     printf "$STARTCOLOR%b$ENDCOLOR" "$1";
 }
+
+
+# There is a delay between creating a service principal and when it is ready for use.
+# This helper function to blocks till Service Principal is ready for use.
+# Usage: wait_service_principal_creation <SERVICE_PRINCIPAL_APP_ID>
+wait_service_principal_creation () {
+    local sp_app_id=$1
+    until az ad sp list --show-mine --query "[].appId" -o tsv | grep "$sp_app_id"
+    do
+        echo "waiting for sp to create..."
+        sleep 10s
+    done
+}

--- a/e2e_samples/parking_sensors_synapse/scripts/deploy_azdo_service_connections_azure.sh
+++ b/e2e_samples/parking_sensors_synapse/scripts/deploy_azdo_service_connections_azure.sh
@@ -31,6 +31,8 @@ set -o pipefail
 set -o nounset
 set -o xtrace # For debugging
 
+. ./scripts/common.sh
+
 ###################
 # REQUIRED ENV VARIABLES:
 #

--- a/e2e_samples/parking_sensors_synapse/scripts/deploy_azdo_service_connections_azure.sh
+++ b/e2e_samples/parking_sensors_synapse/scripts/deploy_azdo_service_connections_azure.sh
@@ -31,7 +31,7 @@ set -o pipefail
 set -o nounset
 set -o xtrace # For debugging
 
-. ./scripts/common.sh
+. ./common.sh
 
 ###################
 # REQUIRED ENV VARIABLES:

--- a/e2e_samples/parking_sensors_synapse/scripts/deploy_azdo_service_connections_azure.sh
+++ b/e2e_samples/parking_sensors_synapse/scripts/deploy_azdo_service_connections_azure.sh
@@ -79,6 +79,7 @@ az devops service-endpoint update \
     --id "$sc_id" \
     --enable-for-all "true"
 
+wait_service_principal_creation "$service_principal_id"
 service_principal_object_id=$(az ad sp show --id "$service_principal_id" --query "objectId" -o tsv)
 role_exists=$(az synapse role assignment list --workspace-name "$SYNAPSE_WORKSPACE_NAME" \
  --query="[?principalId == '$service_principal_object_id' ]" -o tsv)

--- a/e2e_samples/parking_sensors_synapse/scripts/deploy_azdo_service_connections_azure.sh
+++ b/e2e_samples/parking_sensors_synapse/scripts/deploy_azdo_service_connections_azure.sh
@@ -86,7 +86,7 @@ service_principal_object_id=$(az ad sp show --id "$service_principal_id" --query
 role_exists=$(az synapse role assignment list --workspace-name "$SYNAPSE_WORKSPACE_NAME" \
  --query="[?principalId == '$service_principal_object_id' ]" -o tsv)
 if [[ -z $role_exists ]]; then
-    # There is delay until sp is available for role assignment
+    # There is a delay until sp is available for role assignment, so adding retry
     retry 10 az synapse role assignment create --workspace-name "$SYNAPSE_WORKSPACE_NAME" \
     --role "Synapse Administrator" --assignee "$service_principal_object_id"
 else 

--- a/e2e_samples/parking_sensors_synapse/scripts/deploy_azdo_service_connections_azure.sh
+++ b/e2e_samples/parking_sensors_synapse/scripts/deploy_azdo_service_connections_azure.sh
@@ -31,7 +31,7 @@ set -o pipefail
 set -o nounset
 set -o xtrace # For debugging
 
-. ./common.sh
+. ./scripts/common.sh
 
 ###################
 # REQUIRED ENV VARIABLES:

--- a/e2e_samples/parking_sensors_synapse/scripts/deploy_azdo_service_connections_azure.sh
+++ b/e2e_samples/parking_sensors_synapse/scripts/deploy_azdo_service_connections_azure.sh
@@ -86,8 +86,8 @@ service_principal_object_id=$(az ad sp show --id "$service_principal_id" --query
 role_exists=$(az synapse role assignment list --workspace-name "$SYNAPSE_WORKSPACE_NAME" \
  --query="[?principalId == '$service_principal_object_id' ]" -o tsv)
 if [[ -z $role_exists ]]; then
-    sleep 60s; # Wait for SP to be visible to Synapse. 
-    az synapse role assignment create --workspace-name "$SYNAPSE_WORKSPACE_NAME" \
+    # There is delay until sp is available for role assignment
+    retry 10 az synapse role assignment create --workspace-name "$SYNAPSE_WORKSPACE_NAME" \
     --role "Synapse Administrator" --assignee "$service_principal_object_id"
 else 
     echo "Synapse role exists for ${service_principal_object_id}"

--- a/e2e_samples/parking_sensors_synapse/scripts/deploy_infrastructure.sh
+++ b/e2e_samples/parking_sensors_synapse/scripts/deploy_infrastructure.sh
@@ -30,7 +30,7 @@ set -o pipefail
 set -o nounset
 set -o xtrace # For debugging
 
-. ./scripts/common.sh
+. ./common.sh
 
 ###################
 # REQUIRED ENV VARIABLES:

--- a/e2e_samples/parking_sensors_synapse/scripts/deploy_infrastructure.sh
+++ b/e2e_samples/parking_sensors_synapse/scripts/deploy_infrastructure.sh
@@ -30,6 +30,8 @@ set -o pipefail
 set -o nounset
 set -o xtrace # For debugging
 
+. ./scripts/common.sh
+
 ###################
 # REQUIRED ENV VARIABLES:
 #
@@ -229,10 +231,8 @@ KEYVAULT_NAME=$kv_name \
  az keyvault secret set --vault-name "$kv_name" --name "spSynapsePass" --value "$sp_synapse_pass"
  az keyvault secret set --vault-name "$kv_name" --name "spSynapseTenantId" --value "$sp_synapse_tenant"
 
-# Since service principal might take a while to be searchable in the tenant, here we wait for 60s
-# in case immediately assign Synapse RBAC command failed
-sleep 60s
 # Grant Synapse Administrator to this SP so that it can trigger Synapse pipelines
+wait_service_principal_creation "$sp_synapse_id"
 az synapse role assignment create --workspace-name "$synapseworkspace_name" \
     --role "Synapse Administrator" --assignee "$sp_synapse_name"
 

--- a/e2e_samples/parking_sensors_synapse/scripts/deploy_infrastructure.sh
+++ b/e2e_samples/parking_sensors_synapse/scripts/deploy_infrastructure.sh
@@ -30,7 +30,7 @@ set -o pipefail
 set -o nounset
 set -o xtrace # For debugging
 
-. ./common.sh
+. ./scripts/common.sh
 
 ###################
 # REQUIRED ENV VARIABLES:


### PR DESCRIPTION
# Type of PR
<!-- Removed items that do not match with your change. -->

- Code changes

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Currently, there is chance that the deployment fails when upon creating a Service principal, immediately trying to access the service principal (ei. `az ad sp show`) before it is ready. In certain cases, we've solved this by simply doing a sleep command. This utility function is a reausable function that will block the script so it wait till the SP is ready to be queried in a more reliable fashion.

## Does this introduce a breaking change? If yes, details on what can break

## Author pre-publish checklist
<!-- Please check check before publishing PR using "x". Remove a column if it's not applicable. -->
- [ ] Added test to prove my fix is effective or new feature works
- [X] No PII in logs
- [ ] Made corresponding changes to the documentation
