### PR TITLE
Change deploy_infrastructure.sh to use Synapse sp objectId

### DIFF
--- a/e2e_samples/parking_sensors_synapse/scripts/deploy_infrastructure.sh
+++ b/e2e_samples/parking_sensors_synapse/scripts/deploy_infrastructure.sh
@@ -235,8 +235,9 @@ AZURE_STORAGE_ACCOUNT=$azure_storage_account \
 
 # Grant Synapse Administrator to this SP so that it can trigger Synapse pipelines
 wait_service_principal_creation "$sp_synapse_id"
-assign_synapse_role_if_not_exists "$synapseworkspace_name" "Synapse Administrator" "$sp_synapse_name"
-assign_synapse_role_if_not_exists "$synapseworkspace_name" "Synapse SQL Administrator" "$sp_synapse_name"
+sp_synapse_object_id=$(az ad sp show --id "$sp_synapse_id" --query "objectId" -o tsv)
+assign_synapse_role_if_not_exists "$synapseworkspace_name" "Synapse Administrator" "$sp_synapse_object_id"
+assign_synapse_role_if_not_exists "$synapseworkspace_name" "Synapse SQL Administrator" "$sp_synapse_object_id"
 
 
 ####################


### PR DESCRIPTION
* deploy_infrastructure.sh was using the sp_synapse_name. Causing failure due to not finding existing SP.

# Type of PR
<!-- Removed items that do not match with your change. -->

- Documentation changes
- Code changes
- Test changes
- CI-CD changes
- GitHub Template changes

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- ...

## Does this introduce a breaking change? If yes, details on what can break

## Author pre-publish checklist
<!-- Please check check before publishing PR using "x". Remove a column if it's not applicable. -->
- [ ] Added test to prove my fix is effective or new feature works
- [ ] No PII in logs
- [ ] Made corresponding changes to the documentation

## Validation steps
<!-- Optional. -->
- ...

## Issues Closed or Referenced
<!-- This will automatically close the issue when the PR closes. -->
- Closes #issue_number
<!-- this references the issue but does not close with PR. -->
- References #issue_number
