### PR TITLE
Fixed error in parking_sensors/scripts/deploy_infrastructure.sh where…

### DIFF
--- a/e2e_samples/parking_sensors/adf/factory/mdwdops-adf-dev-zyxpf.json
+++ b/e2e_samples/parking_sensors/adf/factory/mdwdops-adf-dev-zyxpf.json
@@ -1,0 +1,9 @@
+{
+	"name": "mdwdops-adf-dev-zyxpf",
+	"location": "northeurope",
+	"identity": {
+		"type": "SystemAssigned",
+		"principalId": "a00f9096-761c-4939-80f6-5566a2aabe87",
+		"tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+	}
+}

--- a/e2e_samples/parking_sensors/adf/linkedService/Ls_AdlsGen2_01.json
+++ b/e2e_samples/parking_sensors/adf/linkedService/Ls_AdlsGen2_01.json
@@ -1,11 +1,11 @@
 {
 	"name": "Ls_AdlsGen2_01",
+	"type": "Microsoft.DataFactory/factories/linkedservices",
 	"properties": {
 		"annotations": [],
 		"type": "AzureBlobFS",
 		"typeProperties": {
-			"url": "https://mdwdopsstdev16.dfs.core.windows.net"
+			"url": "https://mdwdopsstdevzyxpf.dfs.core.windows.net"
 		}
-	},
-	"type": "Microsoft.DataFactory/factories/linkedservices"
+	}
 }

--- a/e2e_samples/parking_sensors/adf/linkedService/Ls_AzureDatabricks_01.json
+++ b/e2e_samples/parking_sensors/adf/linkedService/Ls_AzureDatabricks_01.json
@@ -1,12 +1,13 @@
 {
 	"name": "Ls_AzureDatabricks_01",
+	"type": "Microsoft.DataFactory/factories/linkedservices",
 	"properties": {
 		"annotations": [],
 		"type": "AzureDatabricks",
 		"typeProperties": {
-			"domain": "https://adb-7988601177969121.1.azuredatabricks.net",
+			"domain": "https://adb-4379862556124444.4.azuredatabricks.net",
 			"authentication": "MSI",
-			"workspaceResourceId": "/subscriptions/c20af4c3-6b7a-4ee8-b830-a2a69c4a56ac/resourceGroups/mdwdops-16-dev-rg/providers/Microsoft.Databricks/workspaces/mdwdops-dbw-dev-16",
+			"workspaceResourceId": "/subscriptions/a766b23b-56b3-4bad-a7b7-5a6933177cd4/resourceGroups/mdwdops-zyxpf-dev-rg/providers/Microsoft.Databricks/workspaces/mdwdops-dbw-dev-zyxpf",
 			"newClusterNodeType": "Standard_DS3_v2",
 			"newClusterNumOfWorker": "1",
 			"newClusterSparkEnvVars": {
@@ -15,6 +16,5 @@
 			"newClusterVersion": "7.3.x-scala2.12",
 			"newClusterInitScripts": []
 		}
-	},
-	"type": "Microsoft.DataFactory/factories/linkedservices"
+	}
 }

--- a/e2e_samples/parking_sensors/adf/linkedService/Ls_KeyVault_01.json
+++ b/e2e_samples/parking_sensors/adf/linkedService/Ls_KeyVault_01.json
@@ -5,7 +5,7 @@
 		"annotations": [],
 		"type": "AzureKeyVault",
 		"typeProperties": {
-			"baseUrl": "https://mdwdops-kv-dev-16.vault.azure.net/"
+			"baseUrl": "https://mdwdops-kv-dev-zyxpf.vault.azure.net/"
 		}
 	}
 }

--- a/e2e_samples/parking_sensors/adf/pipeline/P_Ingest_MelbParkingData.json
+++ b/e2e_samples/parking_sensors/adf/pipeline/P_Ingest_MelbParkingData.json
@@ -265,7 +265,7 @@
 			}
 		},
 		"annotations": [],
-		"lastPublishTime": "2021-08-03T05:18:18Z"
+		"lastPublishTime": "2022-07-27T07:57:27Z"
 	},
 	"type": "Microsoft.DataFactory/factories/pipelines"
 }

--- a/e2e_samples/parking_sensors/adf/publish_config.json
+++ b/e2e_samples/parking_sensors/adf/publish_config.json
@@ -1,0 +1,1 @@
+{"publishBranch":"adf_publish"}

--- a/e2e_samples/parking_sensors/adf/trigger/T_Sched.json
+++ b/e2e_samples/parking_sensors/adf/trigger/T_Sched.json
@@ -2,7 +2,7 @@
 	"name": "T_Sched",
 	"properties": {
 		"annotations": [],
-		"runtimeState": "Stopped",
+		"runtimeState": "Started",
 		"pipelines": [
 			{
 				"pipelineReference": {

--- a/e2e_samples/parking_sensors/devops/azure-pipelines-cd-release.yml
+++ b/e2e_samples/parking_sensors/devops/azure-pipelines-cd-release.yml
@@ -13,7 +13,7 @@ resources:
   - repository: mdwdataops_adfpublish
     type: github
     endpoint: mdwdops-github
-    name: devlace/mdw-dataops-clone
+    name: Illuminae/modern-data-warehouse-dataops
     ref: adf_publish
 
 # The deployment script sets this as a Pipeline Variable, but you may choose to set it here in the definition

--- a/e2e_samples/parking_sensors/scripts/deploy_infrastructure.sh
+++ b/e2e_samples/parking_sensors/scripts/deploy_infrastructure.sh
@@ -55,7 +55,7 @@ az group create --name "$resource_group_name" --location "$AZURE_LOCATION" --tag
 
 # By default, set all KeyVault permission to deployer
 # Retrieve KeyVault User Id
-kv_owner_object_id=$(az ad signed-in-user show --output json | jq -r '.objectId')
+kv_owner_object_id=$(az ad signed-in-user show --output json | jq -r '.id')
 
 # Validate arm template
 echo "Validating deployment"


### PR DESCRIPTION
… the attribute for user id on the Microsoft Graph has changed from objectId to just id.

# Type of PR

- Code changes

## Purpose
Yesterday I tried running the deployment and it failed as the objectId in the JSON returned by 
```
az ad signed-in-user show --output json
```
has been renamed to "id". See https://github.com/Azure/azure-cli/issues/9506#issuecomment-1149942398

## Does this introduce a breaking change? If yes, details on what can break

## Author pre-publish checklist
<!-- Please check check before publishing PR using "x". Remove a column if it's not applicable. -->
- [ ] Added test to prove my fix is effective or new feature works
- [ ] Made corresponding changes to the documentation

## Validation steps
<!-- Optional. -->
- ...

## Issues Closed or Referenced
<!-- This will automatically close the issue when the PR closes. -->
- Closes #issue_number
<!-- this references the issue but does not close with PR. -->
- References #issue_number
