### PR TITLE
Dev container config update

### DIFF
--- a/e2e_samples/parking_sensors_synapse/src/ddo_transform/.devcontainer/Dockerfile
+++ b/e2e_samples/parking_sensors_synapse/src/ddo_transform/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See LICENSE in the project root for license information.
 #-----------------------------------------------------------------------------------------
-FROM python:3.7
+FROM python:3.9.5
 
 # Configure apt
 ENV DEBIAN_FRONTEND=noninteractive
@@ -17,7 +17,6 @@ RUN apt-get install -y libicu[0-9][0-9]
 
 # Install java
 RUN apt-get install -y openjdk-11-jdk
-ENV JAVA_HOME=/usr/lib/jvm/java-1.11.0-openjdk-amd64
 
 RUN mkdir /workspace
 WORKDIR /workspace

--- a/e2e_samples/parking_sensors_synapse/src/ddo_transform/.devcontainer/devcontainer.json
+++ b/e2e_samples/parking_sensors_synapse/src/ddo_transform/.devcontainer/devcontainer.json
@@ -1,13 +1,16 @@
 {
 	"name": "PySpark",
 	"dockerComposeFile": "docker-compose.yml",
-	"workspaceFolder": "/workspace",
+	"workspaceFolder": "/workspace/e2e_samples/parking_sensors_synapse/src/ddo_transform",
 	"service": "pyspark",
-	"context": "..",
-	"extensions": [
-		"ms-python.python"
-	],
-	"settings": {
-		"python.pythonPath": "/usr/local/bin/python"
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-python.python"
+			]
+		},
+		"settings": {
+			"python.defaultInterpreterPath": "/usr/local/bin/python"
+		}
 	}
 }

--- a/e2e_samples/parking_sensors_synapse/src/ddo_transform/.devcontainer/docker-compose.yml
+++ b/e2e_samples/parking_sensors_synapse/src/ddo_transform/.devcontainer/docker-compose.yml
@@ -12,8 +12,9 @@ services:
     ports: 
     - 5004:5004
     volumes:
-      # Update this to wherever you want VS Code to mount the folder of your project
-      - ..:/workspace
+      # Update this to wherever you want VS Code to mount the folder of your project.
+      # Use the Git root folder to enable vscode version control integration.
+      - ../../../../..:/workspace
 
       # # This lets you avoid setting up Git again in the container
       # - ~/.gitconfig:/root/.gitconfig

--- a/e2e_samples/parking_sensors_synapse/src/ddo_transform/MANIFEST.in
+++ b/e2e_samples/parking_sensors_synapse/src/ddo_transform/MANIFEST.in
@@ -4,7 +4,6 @@ include HISTORY.rst
 include LICENSE
 include README.rst
 
-include data/On-street_Parking_Bay_Sensors.csv
 recursive-include tests *
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]

--- a/e2e_samples/parking_sensors_synapse/src/ddo_transform/Makefile
+++ b/e2e_samples/parking_sensors_synapse/src/ddo_transform/Makefile
@@ -53,7 +53,7 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr .pytest_cache
 
 lint: ## check style with flake8
-	flake8 $(PYTHON_PACKAGE)
+	flake8
 
 test: ## run tests quickly with the default Python
 	py.test

--- a/e2e_samples/parking_sensors_synapse/src/ddo_transform/Makefile
+++ b/e2e_samples/parking_sensors_synapse/src/ddo_transform/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean clean-test clean-pyc clean-build docs help
+.PHONY: clean clean-test clean-pyc clean-build help
 .DEFAULT_GOAL := help
 
 PYTHON_PACKAGE := ddo_transform

--- a/e2e_samples/parking_sensors_synapse/src/ddo_transform/README.md
+++ b/e2e_samples/parking_sensors_synapse/src/ddo_transform/README.md
@@ -9,7 +9,9 @@
 
 ### Steps to setup Development environment
 
-1. Open VSCode from the **root of the Python project**. That is, the root of your VSCode workspace needs to be at `e2e_samples/parking_sensors/src/ddo_transform`. It should have `.devcontainer` and `.vscode` folders.
+> For [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install) users, note that performance in Devcontainers is significantly better if the repository resides on the WSL file system, and not on the Windows file system.
+
+1. Open VSCode from the **root of the Python project**. That is, the root of your VSCode workspace needs to be at `e2e_samples/parking_sensors/src/ddo_transform`. It should have the `.devcontainer` folder.
 2. Create an `.env` file. Optionally, set the following environment variables.
     - If you will be uploading the package to a Databricks workspace as part of the Development cycle, you need to set the following:
       - **DATABRICKS_HOST** - Databricks workspace url (ei. [https://australiaeast.azuredatabricks.net](https://australiaeast.azuredatabricks.net))
@@ -17,11 +19,22 @@
       - **DATABRICKS_DBFS_PACKAGE_UPLOAD_PATH** - Path in the DBFS where the python package whl file will be uploaded when calling `make uploaddatabricks`.
       - **DATABRICKS_CLUSTER_ID** - Cluster Id of Databricks cluster where package will be installed when calling `make installdatabricks`
 3. In VSCode command pallete (`ctrl+shift+p`), select `Remote-Containers: Reopen in container`. First time building the Devcontainer may take a while.
-4. Run `make` to see options.
+4. Run `make` in integrated terminal to see options.
     ![makefile](./docs/images/make.png)
 
 ### Debugging unit tests
 
-The Devcontainer should have ms-python extension installed and .vscode all the necessary settings. All you need to do is run `Python: Discover tests`, from the vscode command pallete. Now, all tests (currently located under the `src/ddo_transform/tests` folder) should have `Run test | Debug test` annotation:
+The Devcontainer should have ms-python extension installed and .vscode all the necessary settings. All you need to do is [discover tests](https://code.visualstudio.com/docs/python/testing), enabling the Pytest framework.
 
-![Test annotation](./docs/images/test_annotation.png)
+> Note: on the first launch, the test window may show a pytest discovery error. If that
+> occurs, relaunch VSCode.
+
+### Dependency and artifact versions
+
+When determining versions of base Docker images and dependency packages, make sure to align versions with the ones used in the Databricks runtime version currently used in deploymen.
+
+The sample is currently aligned to [Databricks Runtime 12.2 LTS](https://docs.databricks.com/release-notes/runtime/12.2.html). This includes:
+
+- Java 8
+- Scala 2.12
+- Python 3.9.5

--- a/e2e_samples/parking_sensors_synapse/src/ddo_transform/README.md
+++ b/e2e_samples/parking_sensors_synapse/src/ddo_transform/README.md
@@ -1,4 +1,4 @@
-# Python Package - ddo_transfor
+# Python Package - ddo_transform
 
 ## Development setup
 

--- a/e2e_samples/parking_sensors_synapse/src/ddo_transform/ddo_transform/__init__.py
+++ b/e2e_samples/parking_sensors_synapse/src/ddo_transform/ddo_transform/__init__.py
@@ -2,6 +2,4 @@
 
 """Top-level package for ddo_transform."""
 
-__author__ = """Lace Lofranco"""
-__email__ = 'lace.lofranco@microsoft.com'
 __version__ = '1.0.0'

--- a/e2e_samples/parking_sensors_synapse/src/ddo_transform/requirements.txt
+++ b/e2e_samples/parking_sensors_synapse/src/ddo_transform/requirements.txt
@@ -1,1 +1,7 @@
-pyspark==3.2.2
+# Requirements for running the runtime code standalone.
+# These requirements would be installed for running integration tests in a dedicated
+# environment, though no integration tests are currently defined.
+#
+# See README.md regarding version alignment with Databricks runtime.
+#
+pyspark==3.3.0

--- a/e2e_samples/parking_sensors_synapse/src/ddo_transform/requirements_dev.txt
+++ b/e2e_samples/parking_sensors_synapse/src/ddo_transform/requirements_dev.txt
@@ -1,3 +1,6 @@
+# Requirements for developing or testing the code,
+# in addition to requirements defined in requirements.txt.
+#
 pip
 wheel
 watchdog
@@ -5,7 +8,6 @@ flake8
 tox
 coverage
 twine
-click
 pytest
 pytest-runner
 databricks-cli

--- a/e2e_samples/parking_sensors_synapse/src/ddo_transform/setup.cfg
+++ b/e2e_samples/parking_sensors_synapse/src/ddo_transform/setup.cfg
@@ -10,5 +10,5 @@ max-line-length = 120
 test = pytest
 
 [tool:pytest]
-collect_ignore = ['setup.py']
+addopts = --ignore=setup.py
 

--- a/e2e_samples/parking_sensors_synapse/src/ddo_transform/setup.cfg
+++ b/e2e_samples/parking_sensors_synapse/src/ddo_transform/setup.cfg
@@ -1,16 +1,3 @@
-[bumpversion]
-current_version = 0.1.0
-commit = True
-tag = True
-
-[bumpversion:file:setup.py]
-search = version='{current_version}'
-replace = version='{new_version}'
-
-[bumpversion:file:ddo_transform/__init__.py]
-search = __version__ = '{current_version}'
-replace = __version__ = '{new_version}'
-
 [bdist_wheel]
 universal = 1
 

--- a/e2e_samples/parking_sensors_synapse/src/ddo_transform/setup.cfg
+++ b/e2e_samples/parking_sensors_synapse/src/ddo_transform/setup.cfg
@@ -12,3 +12,7 @@ test = pytest
 [tool:pytest]
 addopts = --ignore=setup.py
 
+[metadata]
+# Sourcing the version
+# https://packaging.python.org/en/latest/guides/single-sourcing-package-version/
+version = attr: ddo_transform.__version__

--- a/e2e_samples/parking_sensors_synapse/src/ddo_transform/setup.py
+++ b/e2e_samples/parking_sensors_synapse/src/ddo_transform/setup.py
@@ -3,10 +3,7 @@
 
 """The setup script."""
 
-import os
 from setuptools import setup, find_packages
-
-version = os.environ['PACKAGE_VERSION']
 
 with open('README.md') as readme_file:
     readme = readme_file.read()
@@ -14,7 +11,7 @@ with open('README.md') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-requirements = ['Click>=6.0', ]
+requirements = []
 
 setup_requirements = ['pytest-runner', ]
 
@@ -38,22 +35,15 @@ setup(
         'Programming Language :: Python :: 3.8',
     ],
     description="Python Boilerplate contains all the boilerplate you need to create a Python package.",
-    entry_points={
-        'console_scripts': [
-            'ddo_transform=ddo_transform.cli:main',
-        ],
-    },
     install_requires=requirements,
     license="MIT license",
     long_description=readme + '\n\n' + history,
     include_package_data=True,
-    keywords='ddo_transform',
     name='ddo_transform',
     packages=find_packages(include=['ddo_transform']),
     setup_requires=setup_requirements,
     test_suite='tests',
     tests_require=test_requirements,
-    url='https://github.com/devlace/datadevops',
-    version=version,
+    url='https://github.com/Azure-Samples/modern-data-warehouse-dataops/tree/main/e2e_samples/parking_sensors',
     zip_safe=False,
 )


### PR DESCRIPTION
# Type of PR
<!-- Removed items that do not match with your change. -->

- Documentation changes
- Code changes

## Purpose

Upgrade dev container configuration to current standards, and misc improvements.

- Removed JAVA_HOME Docker env var, as the path is incorrect on non AMD64 arch (e.g. Mac M1), and variable is not needed by Pyspark
- Aligned python versions with Databricks Runtime
- Updated devcontainers.json format to current standard (previous format gave warnings in viscose)
- Include .git folder in container to enable git integration
- Also lint tests with flake8, not only runtime code
- Updated README for new behavior of test extension
- Updated obsolete collect_ignore pytest parameter
- Misc improvements

## Does this introduce a breaking change? If yes, details on what can break

No

## Author pre-publish checklist

## Validation steps

Run unit tests in dev container on VSCode

## Issues Closed or Referenced
