### PR TITLE
fix(parking-sensors): added temurin-8-jdk

### DIFF
--- a/e2e_samples/parking_sensors/src/ddo_transform/.devcontainer/Dockerfile
+++ b/e2e_samples/parking_sensors/src/ddo_transform/.devcontainer/Dockerfile
@@ -16,8 +16,13 @@ RUN apt-get -y install git procps lsb-release
 RUN apt-get install -y libicu[0-9][0-9]
 
 # Install java
-RUN apt-get install -y openjdk-11-jdk
-ENV JAVA_HOME=/usr/lib/jvm/java-1.11.0-openjdk-amd64
+RUN wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public | apt-key add -
+RUN echo "deb https://packages.adoptium.net/artifactory/deb \
+$(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" \
+| tee /etc/apt/sources.list.d/adoptium.list
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends \
+      temurin-8-jdk
 
 RUN mkdir /workspace
 WORKDIR /workspace

--- a/e2e_samples/parking_sensors/src/ddo_transform/.devcontainer/Dockerfile
+++ b/e2e_samples/parking_sensors/src/ddo_transform/.devcontainer/Dockerfile
@@ -22,7 +22,7 @@ $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" \
 | tee /etc/apt/sources.list.d/adoptium.list
 RUN apt-get update \
     && apt-get -y install --no-install-recommends \
-      temurin-8-jdk
+      temurin-11-jdk
 
 RUN mkdir /workspace
 WORKDIR /workspace

--- a/e2e_samples/parking_sensors_synapse/src/ddo_transform/.devcontainer/Dockerfile
+++ b/e2e_samples/parking_sensors_synapse/src/ddo_transform/.devcontainer/Dockerfile
@@ -16,8 +16,13 @@ RUN apt-get -y install git procps lsb-release
 RUN apt-get install -y libicu[0-9][0-9]
 
 # Install java
-RUN apt-get install -y openjdk-11-jdk
-ENV JAVA_HOME=/usr/lib/jvm/java-1.11.0-openjdk-amd64
+RUN wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public | apt-key add -
+RUN echo "deb https://packages.adoptium.net/artifactory/deb \
+$(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" \
+| tee /etc/apt/sources.list.d/adoptium.list
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends \
+      temurin-8-jdk
 
 RUN mkdir /workspace
 WORKDIR /workspace

--- a/e2e_samples/parking_sensors_synapse/src/ddo_transform/.devcontainer/Dockerfile
+++ b/e2e_samples/parking_sensors_synapse/src/ddo_transform/.devcontainer/Dockerfile
@@ -22,7 +22,7 @@ $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" \
 | tee /etc/apt/sources.list.d/adoptium.list
 RUN apt-get update \
     && apt-get -y install --no-install-recommends \
-      temurin-8-jdk
+      temurin-11-jdk
 
 RUN mkdir /workspace
 WORKDIR /workspace


### PR DESCRIPTION
# Type of PR
- Code changes

## Purpose
In bug #644 we see a failing devcontainer setup when running the parking-sensors samples locally this fixes the issue


## Author pre-publish checklist

- [ ] Added test to prove my fix is effective or new feature works
- [ ] No PII in logs
- [ ] Made corresponding changes to the documentation

## Validation steps
Run the devcontainer locally like described in the issue #644 

## Issues Closed or Referenced
- Closes #644 
