### PR TITLE
Create bicep audit workflow

### DIFF
--- a/.github/workflows/bicep-audit.yml
+++ b/.github/workflows/bicep-audit.yml
@@ -1,0 +1,35 @@
+name: Validate AZD template
+on:
+  push:
+    branches: 
+      - main
+    paths:
+      - "infra/**"
+  pull_request:
+    branches: 
+      - main
+    paths:
+      - "infra/**"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Microsoft Security DevOps Analysis
+        uses: microsoft/security-devops-action@preview
+        id: msdo
+        continue-on-error: true
+        with:
+          tools: templateanalyzer
+
+      - name: Upload alerts to Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: github.repository_owner == 'Azure-Samples'
+        with:
+          sarif_file: ${{ steps.msdo.outputs.sarifFile }}

--- a/.github/workflows/bicep-audit.yml
+++ b/.github/workflows/bicep-audit.yml
@@ -1,15 +1,15 @@
 name: Validate AZD template
 on:
   push:
-    branches: 
-      - main
+    branches:
+    - main
     paths:
-      - "infra/**"
+    - "infra/**"
   pull_request:
-    branches: 
-      - main
+    branches:
+    - main
     paths:
-      - "infra/**"
+    - "infra/**"
   workflow_dispatch:
 
 jobs:
@@ -18,18 +18,18 @@ jobs:
     permissions:
       security-events: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+    - name: Checkout
+      uses: actions/checkout@v4
 
-      - name: Run Microsoft Security DevOps Analysis
-        uses: microsoft/security-devops-action@preview
-        id: msdo
-        continue-on-error: true
-        with:
-          tools: templateanalyzer
+    - name: Run Microsoft Security DevOps Analysis
+      uses: microsoft/security-devops-action@preview
+      id: msdo
+      continue-on-error: true
+      with:
+        tools: templateanalyzer
 
-      - name: Upload alerts to Security tab
-        uses: github/codeql-action/upload-sarif@v3
-        if: github.repository_owner == 'Azure-Samples'
-        with:
-          sarif_file: ${{ steps.msdo.outputs.sarifFile }}
+    - name: Upload alerts to Security tab
+      uses: github/codeql-action/upload-sarif@v3
+      if: github.repository_owner == 'Azure-Samples'
+      with:
+        sarif_file: ${{ steps.msdo.outputs.sarifFile }}


### PR DESCRIPTION
This adds a bicep review tool that will look for security issues in the bicep files and add them to the code scanning reports in the security tab. 

I ran the tool manually on this repo and it identified 47 items to review, it would be useful to do this automatically to track regressions as well.