### PR TITLE
Infra Password and SQL Password

### DIFF
--- a/e2e_samples/parking_sensors/scripts/deploy_infrastructure.sh
+++ b/e2e_samples/parking_sensors/scripts/deploy_infrastructure.sh
@@ -187,11 +187,9 @@ validate_password() {
         echo "Invalid password. The first character cannot be a hyphen. Replacing..."
         password="R${password:1}"
         echo "$password"
-        return 1
     fi
     echo "Password Validated"
     echo "$password"
-    return 0
 }
 
 

--- a/e2e_samples/parking_sensors/scripts/deploy_infrastructure.sh
+++ b/e2e_samples/parking_sensors/scripts/deploy_infrastructure.sh
@@ -176,24 +176,22 @@ az keyvault secret set --vault-name "$kv_name" --name "applicationInsightsKey" -
 az keyvault secret set --vault-name "$kv_name" --name "applicationInsightsConnectionString" --value "$appinsights_connstr"
 
 # ###########################
-echo "validate_password function."
+echo "validate_password function..."
 # ###########################
 validate_password() {
     local password="$1"
-    local max_retries="$2"
-    local retry_count="$3"
+    echo "Validating...$password"
 
-    if [[ -z "$password" || "$password" == "-" ]]; then
-        ###if there is an hyphen retry
-        ((retry_count++))
-        if [[ $retry_count -ge $max_retries ]]; then
-            echo "Error: Failed to generate a valid password after $max_retries retries." >&2
-            exit 1
-        fi
-        echo "Invalid password. The first character cannot be a hyphen. Retrying... Attempt $retry_count"
-        return 1  
+    if [[ -z "$password" || "${password:0:1}" == "-" ]]; then
+        ### if there is a hyphen retry
+        echo "Invalid password. The first character cannot be a hyphen. Replacing..."
+        password="R${password:1}"
+        echo "$password"
+        return 1
     fi
-    return 0 
+    echo "Password Validated"
+    echo "$password"
+    return 0
 }
 
 
@@ -204,40 +202,28 @@ validate_password() {
 echo "Creating Service Principal (SP) for access to ADLA Gen2 used in Databricks mounting"
 
 # ###########################
-###if there is an hyphen retry and recreate the SP with a new password
+###if there is an hyphen in the first position replace by R
 # ###########################
-
-max_retries=2
-retry_count=0
-while true; do
-
-    stor_id=$(az storage account show \
-        --name "$azure_storage_account" \
-        --resource-group "$resource_group_name" \
-        --output json |
-        jq -r '.id')
-    sp_stor_name="${PROJECT}-stor-${ENV_NAME}-${DEPLOYMENT_ID}-sp"
-    sp_stor_out=$(az ad sp create-for-rbac \
-        --role "Storage Blob Data Contributor" \
-        --scopes "$stor_id" \
-        --name "$sp_stor_name" \
-        --output json)
+stor_id=$(az storage account show \
+    --name "$azure_storage_account" \
+    --resource-group "$resource_group_name" \
+    --output json |
+    jq -r '.id')
+sp_stor_name="${PROJECT}-stor-${ENV_NAME}-${DEPLOYMENT_ID}-sp"
+sp_stor_out=$(az ad sp create-for-rbac \
+    --role "Storage Blob Data Contributor" \
+    --scopes "$stor_id" \
+    --name "$sp_stor_name" \
+    --output json)
 
     
-    # store storage service principal details in Keyvault
-    sp_stor_id=$(echo "$sp_stor_out" | jq -r '.appId')
-    sp_stor_pass=$(echo "$sp_stor_out" | jq -r '.password')
-    sp_stor_tenant=$(echo "$sp_stor_out" | jq -r '.tenant')
+# store storage service principal details in Keyvault
+sp_stor_id=$(echo "$sp_stor_out" | jq -r '.appId')
+sp_stor_pass=$(echo "$sp_stor_out" | jq -r '.password')
+sp_stor_tenant=$(echo "$sp_stor_out" | jq -r '.tenant')
 
-    # Validate the password
-    validate_password "$sp_stor_pass" "$max_retries" "$retry_count"
-    if [[ $? -eq 0 ]]; then
-        break  
-    fi
-
-    ((retry_count++))
-    sleep 2  
-done
+# Validate the password
+sp_stor_pass=$(validate_password "$sp_stor_pass")
 
 echo "ADLS - Valid password obtained"
 
@@ -316,26 +302,18 @@ retry_count=0
 # ###########################
 ###if there is an hyphen retry and recreate the SP with a new password
 # ###########################
-while true; do
-    sp_adf_name="${PROJECT}-adf-${ENV_NAME}-${DEPLOYMENT_ID}-sp"
-    sp_adf_out=$(az ad sp create-for-rbac \
-        --role "Data Factory contributor" \
-        --scopes "/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$resource_group_name/providers/Microsoft.DataFactory/factories/$datafactory_name" \
-        --name "$sp_adf_name" \
-        --output json)
-    sp_adf_id=$(echo "$sp_adf_out" | jq -r '.appId')
-    sp_adf_pass=$(echo "$sp_adf_out" | jq -r '.password')
-    sp_adf_tenant=$(echo "$sp_adf_out" | jq -r '.tenant')
+sp_adf_name="${PROJECT}-adf-${ENV_NAME}-${DEPLOYMENT_ID}-sp"
+sp_adf_out=$(az ad sp create-for-rbac \
+    --role "Data Factory contributor" \
+    --scopes "/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$resource_group_name/providers/Microsoft.DataFactory/factories/$datafactory_name" \
+    --name "$sp_adf_name" \
+    --output json)
+sp_adf_id=$(echo "$sp_adf_out" | jq -r '.appId')
+sp_adf_pass=$(echo "$sp_adf_out" | jq -r '.password')
+sp_adf_tenant=$(echo "$sp_adf_out" | jq -r '.tenant')
 
-    # Validate the password
-    validate_password "$sp_adf_pass" "$max_retries" "$retry_count"
-    if [[ $? -eq 0 ]]; then
-        break  # Exit loop if password is valid
-    fi
-
-    ((retry_count++))
-    sleep 2  # Optional delay before retrying
-done
+# Validate the password
+sp_adf_pass=$(validate_password "$sp_adf_pass")
 
 echo "ADF - Valid password obtained"
 
@@ -365,7 +343,6 @@ KV_URL=$kv_dns_name \
 DATABRICKS_TOKEN=$databricks_token \
 DATABRICKS_HOST=$databricks_host \
 DATABRICKS_WORKSPACE_RESOURCE_ID=$databricks_workspace_resource_id \
-DATABRICKS_CLUSTER_ID=$(echo "$arm_output" | jq -r '.properties.outputs.databricks_cluster_id.value') \
 SQL_SERVER_NAME=$sql_server_name \
 SQL_SERVER_USERNAME=$sql_server_username \
 SQL_SERVER_PASSWORD=$AZURESQL_SERVER_PASSWORD \

--- a/e2e_samples/parking_sensors/scripts/deploy_infrastructure.sh
+++ b/e2e_samples/parking_sensors/scripts/deploy_infrastructure.sh
@@ -178,6 +178,8 @@ az keyvault secret set --vault-name "$kv_name" --name "applicationInsightsConnec
 # ###########################
 echo "validate_password function..."
 # ###########################
+###if there is an hyphen in the first position replace by R
+# ###########################
 validate_password() {
     local password="$1"
     echo "Validating...$password"
@@ -197,11 +199,8 @@ validate_password() {
 # # RETRIEVE DATABRICKS INFORMATION AND CONFIGURE WORKSPACE
 
 # Note: SP is required because Credential Passthrough does not support ADF (MSI) as of July 2021
-echo "Creating Service Principal (SP) for access to ADLA Gen2 used in Databricks mounting"
+echo "Creating Service Principal (SP) for access to ADLS Gen2 used in Databricks mounting"
 
-# ###########################
-###if there is an hyphen in the first position replace by R
-# ###########################
 stor_id=$(az storage account show \
     --name "$azure_storage_account" \
     --resource-group "$resource_group_name" \
@@ -297,9 +296,6 @@ ADF_DIR=$adfTempDir \
 echo "Create Service Principal (SP) for Data Factory"
 max_retries=2
 retry_count=0
-# ###########################
-###if there is an hyphen retry and recreate the SP with a new password
-# ###########################
 sp_adf_name="${PROJECT}-adf-${ENV_NAME}-${DEPLOYMENT_ID}-sp"
 sp_adf_out=$(az ad sp create-for-rbac \
     --role "Data Factory contributor" \

--- a/e2e_samples/parking_sensors/scripts/init_environment.sh
+++ b/e2e_samples/parking_sensors/scripts/init_environment.sh
@@ -47,5 +47,6 @@ fi
 AZURESQL_SERVER_PASSWORD=${AZURESQL_SERVER_PASSWORD:-}
 if [ -z "$AZURESQL_SERVER_PASSWORD" ]
 then 
-    export AZURESQL_SERVER_PASSWORD="$(makepasswd --chars 16)"
+    #Increase the complexity by appending the complex string, as some passwords are not cmplex enough.
+    export AZURESQL_SERVER_PASSWORD="P@_Sens0r$(makepasswd --chars 16)"
 fi


### PR DESCRIPTION
# Type of PR
<!-- Removed items that do not match with your change. -->- Code changes

1 - Deploy deploy_infrastructure
- Simplify the logic - If the character is Hypen
- replace by R. Instead of a retry logic

2 - Init_enviromnent:
- Added more complex string concatenated to
- SQL password


## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

1 - Deploy deploy_infrastructure
- Simplify the logic - If the character is Hypen
- replace by R. Instead of a retry logic

2 - Init_enviromnent:
- Added more complex string concatenated to
- SQL password

## Does this introduce a breaking change? If yes, details on what can break

## Author pre-publish checklist
<!-- Please check check before publishing PR using "x". Remove a column if it's not applicable. -->
- [ X] Added test to prove my fix is effective or new feature works
- [ X] No PII in logs
- [ ] Made corresponding changes to the documentation

## Validation steps

Testes log result example:
+ sp_stor_pass='Validating...-fm8....
Invalid password. The first character cannot be a hyphen. Replacing...
Rfm8....
Password Validated
+ echo 'ADLS - Valid password obtained'

## Issues Closed or Referenced
<!-- This will automatically close the issue when the PR closes. -->
- Closes #issue_number
<!-- this references the issue but does not close with PR. -->
- References #issue_number
