### PR TITLE
revert: PR 890 due to inconsistecy

### DIFF
--- a/e2e_samples/parking_sensors/scripts/verify_prerequisites.sh
+++ b/e2e_samples/parking_sensors/scripts/verify_prerequisites.sh
@@ -6,5 +6,4 @@ command -v az >/dev/null 2>&1 || { echo >&2 "I require azure cli but it's not in
 command -v databricks >/dev/null 2>&1 || { echo >&2 "I require databricks cli but it's not installed. See https://github.com/databricks/databricks-cli. Aborting."; exit 1; }
 
 # Check if user is logged in
-# If user is not logged in then abort and guide them to look at the Readme file
-[[ -n $(az account show 2> /dev/null) ]] || { echo "Please login via the Azure CLI and restart the deployment. Check the prerequisites in the Readme. Aborting."; exit 1; }
+[[ -n $(az account show 2> /dev/null) ]] || { echo "Please login via the Azure CLI: "; az login; }

--- a/single_tech_samples/fabric/fabric_ci_cd/README.md
+++ b/single_tech_samples/fabric/fabric_ci_cd/README.md
@@ -57,19 +57,16 @@ Refer to the [know issues, limitations, and workarounds](./issues-limitations-an
 
 Here are the steps to use the bootstrap script:
 
-1. Clone the repository and get the subscription information for your environment variables:
+1. Clone the repository:
 
     ```bash
     # Optional
     az login --tenant "<tenant_id>"
     az account set -s "<subscription_id>"
-    az account show
     cd "<installation_folder>"
     # Repo clone
     git clone https://github.com/Azure-Samples/modern-data-warehouse-dataops.git
     ```
-
-Note: While running the az login --tenant command you may be prompted for a number that refers to the Subscription ID. If you are prompted for this number then there is no need to run the az account set command again.
 
 1. Change the directory to the sample folder:
 
@@ -333,12 +330,6 @@ To automate this process to some extent, you can use the [update-token-to-azdo-v
 
 - Prompts the user to run `az login` interactively and generates the Fabric bearer token with the appropriate scope.
 - Adds or updates the "token" variable in the Azure DevOps variable group, marking it as "secret".
-- In order to run this script you will need to retrieve and modify the following variables at the beginning of the script:
-  - organization_url="<AZURE_DEVOPS_ORGANIZATION_URL>"
-  - tenant_id="<TENANT_ID>"
-  - project="<AZURE_DEVOPS_PROJECT_NAME>"
-  - variable_group_name="<AZURE_DEVOPS_VARIABLE_GROUP_NAME>"
-  - variable_name="token"
 
 You can modify this script to update the "token" variable in your Azure DevOps variable group(s) by running it before triggering the Azure DevOps pipeline. It is recommended that this script be run by a user with the "Fabric administrator" role and "Edit" permissions on the Azure DevOps variable group(s).
 

--- a/single_tech_samples/fabric/fabric_ci_cd/scripts/update-token-to-azdo-variable/update-token-to-azdo-variable.sh
+++ b/single_tech_samples/fabric/fabric_ci_cd/scripts/update-token-to-azdo-variable/update-token-to-azdo-variable.sh
@@ -1,18 +1,14 @@
 #!/bin/bash
 # Set your variables
-# Refer to the Readme on how to get and set your variables
 organization_url="<AZURE_DEVOPS_ORGANIZATION_URL>"
 tenant_id="<TENANT_ID>"
 project="<AZURE_DEVOPS_PROJECT_NAME>"
 variable_group_name="<AZURE_DEVOPS_VARIABLE_GROUP_NAME>"
 variable_name="token"
 
-# Check if user is logged in
-# If user is not logged in then abort and guide them to look at the Readme file
-[[ -n $(az account show 2> /dev/null) ]] || { echo "Please login via the Azure CLI and restart the deployment. Check the prerequisites in the Readme. Aborting."; exit 1; }
-
-# Follow the instructions in the Readme on how to do "az login" to get the access token
-# The subscription should already be logged in and thus you can get the access token
+# Do "az login" to get the access token
+az config set core.login_experience_v2=off
+az login --tenant ${tenant_id}
 token=$(az account get-access-token \
           --resource "https://login.microsoftonline.com/${tenant_id}" \
           --query accessToken \


### PR DESCRIPTION
# Type of PR
- Revert previous PR

## Purpose
- PR #890 - changes were done in two different samples Single Tech Fabric CICD(ReadMe) and E2E DB(Scripts) - changes are inconsistent. They need to address the E2E DB repo fully.

## Does this introduce a breaking change? If yes, details on what can break
No.

## Author pre-publish checklist
- [ ] Added test to prove my fix is effective or new feature works
- [X] No PII in logs
- [ ] Made corresponding changes to the documentation

## Validation steps
- Check changes against PR890.

## Issues Closed or Referenced
N\A

