### PR TITLE
added Apple Silicon support for the devcontainer image #918 #888

### DIFF
--- a/e2e_samples/parking_sensors/.devcontainer/Dockerfile
+++ b/e2e_samples/parking_sensors/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See LICENSE in the project root for license information.
 #-----------------------------------------------------------------------------------------
-FROM python:3
+FROM --platform=linux/amd64 python:3
 
 # Configure apt
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
# Type of PR
<!-- Removed items that do not match with your change. -->

- Code changes

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- added Apple Silicon support for the python devcontainer image because it would use the arm64 instead which causes issues with Docker Desktop and Rosetta support

## Does this introduce a breaking change? If yes, details on what can break

## Author pre-publish checklist
<!-- Please check check before publishing PR using "x". Remove a column if it's not applicable. -->
- [x] Added test to prove my fix is effective or new feature works
- [ ] No PII in logs
- [ ] Made corresponding changes to the documentation

## Issues Closed or Referenced
<!-- this references the issue but does not close with PR. -->
- References #918
