### PR TITLE
update for cluster config and template

### DIFF
--- a/e2e_samples/parking_sensors/databricks/config/cluster.config.json
+++ b/e2e_samples/parking_sensors/databricks/config/cluster.config.json
@@ -1,8 +1,8 @@
 {
     "cluster_name": "ddo_cluster",
     "autoscale": { "min_workers": 1, "max_workers": 2 },
-    "spark_version": "14.3.x-scala2.12",
-    "autotermination_minutes": 30,
+    "spark_version": "15.4.x-scala2.12",
+    "autotermination_minutes": 10,
     "node_type_id": "Standard_D4as_v5",
     "data_security_mode": "SINGLE_USER",
     "runtime_engine": "PHOTON",

--- a/e2e_samples/parking_sensors/databricks/config/cluster.config.template.json
+++ b/e2e_samples/parking_sensors/databricks/config/cluster.config.template.json
@@ -1,8 +1,8 @@
 {
     "cluster_name": "__REPLACE_CLUSTER_NAME__",
     "autoscale": { "min_workers": 1, "max_workers": 2 },
-    "spark_version": "14.3.x-scala2.12",
-    "autotermination_minutes": 30,
+    "spark_version": "15.4.x-scala2.12",
+    "autotermination_minutes": 10,
     "node_type_id": "Standard_DC4as_v5",
     "data_security_mode": "SINGLE_USER",
     "runtime_engine": "PHOTON",


### PR DESCRIPTION
# Type of PR

Template change for Databricks Cluster Configuration

## Purpose
Update cluster configuration and template file. Newer spark version and change to auto termination (reduced to 10 minutes).

## Does this introduce a breaking change? If yes, details on what can break
Configurations and notebooks that reference the use of DBFS (internal databricks file system) - Investigation notes in comments below

## Author pre-publish checklist
<!-- Please check check before publishing PR using "x". Remove a column if it's not applicable. -->

## Issues Closed or Referenced
<!-- This will automatically close the issue when the PR closes. -->
- Closes #896 

