### PR TITLE
fix: adding TLS definition in sql ded pool

### DIFF
--- a/e2e_samples/parking_sensors/infrastructure/modules/synapse_sql_pool.bicep
+++ b/e2e_samples/parking_sensors/infrastructure/modules/synapse_sql_pool.bicep
@@ -21,6 +21,7 @@ resource sql_server 'Microsoft.Sql/servers@2023-08-01-preview' = {
   properties: {
     administratorLogin: sql_server_username
     administratorLoginPassword: sql_server_password
+    minimalTlsVersion: '1.2' 
 }
 
   resource synapse_dedicated_sql_pool 'databases@2023-05-01-preview' = {


### PR DESCRIPTION
# Type of PR
- Code changes

## Purpose
SQL dedicated pool was being deployed with not TLS definition. TLS 1.2 has been added as part of the deployment.

## Does this introduce a breaking change? If yes, details on what can break
Not with 1.2.

## Author pre-publish checklist
- [X] Added test to prove my fix is effective or new feature works
- [X] No PII in logs
- [ ] Made corresponding changes to the documentation

## Validation steps
- Deploy the sample, verify in the Networking settings of the SQL pool that the TLS has been set to 1.2.
- Check that the remaining functionality works - ADF pipeline Stored procedure task

## Issues Closed or Referenced
- Closes #940 

