### PR TITLE
pre-commit hook fix (removing no-commit-to-branch (main) hook.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,8 +10,6 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
-      - id: no-commit-to-branch
-        args: [--branch, main]
       - id: check-merge-conflict
       - id: trailing-whitespace
       - id: check-ast

--- a/docs/pre_commit_guide.md
+++ b/docs/pre_commit_guide.md
@@ -117,7 +117,6 @@ pre-commit run terraform_tflint --all-files
 Below is a list of the currently configured hooks with brief descriptions. Note that this list may change or evolve as the repository and workflows are updated.
 
 1. **General Checks:**
-   - `no-commit-to-branch`: Prevents committing directly to the `main` branch.
    - `check-merge-conflict`: Checks for unresolved merge conflicts.
    - `trailing-whitespace`, `end-of-file-fixer`, `mixed-line-ending`: Enforces consistent whitespace formatting.
    - `check-ast`, `check-json`, `check-toml`, `check-yaml`: Validates syntax for various file types.


### PR DESCRIPTION
# Type of PR
Fixing pre-commit hooks. Removing (removing no-commit-to-branch (main) hook). This is enforced at repository level.

- Documentation changes
- Code changes


## Purpose
As we are running code quality checks on main branch too, we need to remove this hook so that it won't fail at GitHub actions level. 

hook removed : no-commit-to-branch (main) 

## Does this introduce a breaking change? If yes, details on what can break

No

## Author pre-publish checklist
<!-- Please check check before publishing PR using "x". Remove a column if it's not applicable. -->
- [] Added test to prove my fix is effective or new feature works
- [x] No PII in logs
- [x] Made corresponding changes to the documentation

## Validation steps
All code quality checks on main branch should pass.
