### PR TITLE
[E2E Databricks] - Automate region vm + dbx type cluster in the region

### DIFF
--- a/e2e_samples/parking_sensors/README.md
+++ b/e2e_samples/parking_sensors/README.md
@@ -294,16 +294,6 @@ Set up the environment variables as specified, fork the GitHub repository, and l
      **Login and Cluster Configuration**
       
       - Ensure that you have completed the configuration for the variables described in the previous section, titled **Configuration: Variables and Login**.
-      
-        - This configuration will be used during the environment deployment process to facilitate login.
-        - Create a `cluster.config.json` Spark configuration from the [`cluster.config.template.json`](./databricks/config/cluster.config.template.json) file. For the "node_type_id" field, select a SKU that is available from the following command in your subscription:
-      
-          ```bash
-            az vm list-usage --location "<YOUR_REGION>" -o table
-          ```
-
-    
-          In the repository we provide an example, but you need to make sure that the SKU exists on your region and that is available for your subscription.
 
 2. **Deploy Azure resources**
    - `cd` into the `e2e_samples/parking_sensors` folder of the repo.

--- a/e2e_samples/parking_sensors/scripts/configure_databricks.sh
+++ b/e2e_samples/parking_sensors/scripts/configure_databricks.sh
@@ -27,6 +27,7 @@ set -o nounset
 # KEYVAULT_RESOURCE_ID
 # KEYVAULT_DNS_NAME
 # USER_NAME
+# AZURE_LOCATION
 
 . ./scripts/common.sh
 
@@ -53,6 +54,42 @@ databricks workspace import "$databricks_folder_name/00_setup.py" --file "./data
 databricks workspace import "$databricks_folder_name/01_explore.py" --file "./databricks/notebooks/01_explore.py" --format SOURCE --language PYTHON --overwrite
 databricks workspace import "$databricks_folder_name/02_standardize.py" --file "./databricks/notebooks/02_standardize.py" --format SOURCE --language PYTHON --overwrite
 databricks workspace import "$databricks_folder_name/03_transform.py" --file "./databricks/notebooks/03_transform.py" --format SOURCE --language PYTHON --overwrite
+
+# Define suitable VM for DB cluster
+file_path="./databricks/config/cluster.config.json"
+
+# Get available VM sizes in the specified region
+vm_sizes=$(az vm list-sizes --location "$AZURE_LOCATION" --output json)
+
+# Get available Databricks node types using the list-node-types API
+node_types=$(databricks clusters list-node-types --output json)
+
+# Extract VM names and node type IDs into temporary files
+echo "$vm_sizes" | jq -r '.[] | .name' > vm_names.txt
+echo "$node_types" | jq -r '.node_types[].node_type_id' > node_type_ids.txt
+
+# Find common VM sizes
+common_vms=$(grep -Ff node_type_ids.txt vm_names.txt)
+
+# Find the VM with the least resources
+least_resource_vm=$(echo "$vm_sizes" | jq --arg common_vms "$common_vms" '
+  map(select(.name == ($common_vms | split("\n")[]))) |
+  sort_by(.numberOfCores, .memoryInMb) |
+  .[0]
+')
+log "VM with the least resources:$least_resource_vm" "info"
+
+# Update the JSON file with the least resource VM
+if [ -n "$least_resource_vm" ]; then
+    node_type_id=$(echo "$least_resource_vm" | jq -r '.name')
+    jq --arg node_type_id "$node_type_id" '.node_type_id = $node_type_id' "$file_path" > tmp.$$.json && mv tmp.$$.json "$file_path"
+    log "The JSON file at '$file_path' has been updated with the node_type_id: $node_type_id"
+else
+    log "No common VM options found between Azure and Databricks." "error"
+fi
+
+# Clean up temporary files
+rm vm_names.txt node_type_ids.txt
 
 # Create initial cluster, if not yet exists
 # cluster.config.json file needs to refer to one of the available SKUs on yout Region

--- a/e2e_samples/parking_sensors/scripts/deploy_infrastructure.sh
+++ b/e2e_samples/parking_sensors/scripts/deploy_infrastructure.sh
@@ -270,6 +270,7 @@ DATABRICKS_TOKEN=$databricks_aad_token \
 DATABRICKS_HOST=$databricks_host \
 KEYVAULT_DNS_NAME=$kv_dns_name \
 USER_NAME=$kv_owner_name \
+AZURE_LOCATION=$AZURE_LOCATION \
 KEYVAULT_RESOURCE_ID=$(echo "$arm_output" | jq -r '.properties.outputs.keyvault_resource_id.value') \
     bash -c "./scripts/configure_databricks.sh"
 


### PR DESCRIPTION
# Type of PR
- Documentation changes
- Code changes

## Purpose
- This PR removes the need of configuring the databricks cluster node type manually on the cluster.config.json file based on the region where the deployment is being made.

## Does this introduce a breaking change? If yes, details on what can break
Yes, the deployment can exit if a common vm is not found for that region and subscription.

## Author pre-publish checklist
- [  ] Added test to prove my fix is effective or new feature works
- [ X ] No PII in logs
- [ X ] Made corresponding changes to the documentation

## Validation steps
- Open the repo in the dev container
- Deploy the sample
- When configuring databricks notice a message saying: VM with the least resources: {json}
- Check if the cluster.config.json has been replaced with the value indicated in the previous step

## Issues Closed or Referenced
- Closes #885 
- References #888 
