### PR TITLE
[Unity Catalog] Updates for standardize and transform notebooks #983

### DIFF
--- a/e2e_samples/parking_sensors/databricks/notebooks/02_standardize.py
+++ b/e2e_samples/parking_sensors/databricks/notebooks/02_standardize.py
@@ -25,6 +25,14 @@ base_path = os.path.join('dbfs:/mnt/datalake/data/lnd/', infilefolder)
 parkingbay_filepath = os.path.join(base_path, "MelbParkingBayData.json")
 sensors_filepath = os.path.join(base_path, "MelbParkingSensorData.json")
 
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Use the Sensor Catalog Created in the Prerequisites 
+
+# COMMAND ----------
+# MAGIC %sql
+# MAGIC USE Catalog sensordata
 
 # COMMAND ----------
 

--- a/e2e_samples/parking_sensors/databricks/notebooks/03_transform.py
+++ b/e2e_samples/parking_sensors/databricks/notebooks/03_transform.py
@@ -9,6 +9,15 @@ loadid = dbutils.widgets.get("loadid")
 
 # COMMAND ----------
 
+# MAGIC %md
+# MAGIC ## Use the Sensor Catalog Created in the Prerequisites 
+
+# COMMAND ----------
+# MAGIC %sql
+# MAGIC USE Catalog sensordata
+
+# COMMAND ----------
+
 import datetime
 import os
 from pyspark.sql.functions import col, lit


### PR DESCRIPTION
# Type of PR
Updates to standardize and transform notebooks
- Code changes


## Purpose
This is an upgrade for two notebooks (02_standarize.py and 03_transform.py).  These notebooks execute from an ADF pipeline and are designed to standardize and transform the json payload retrieved from the parking sensors into dimensions.  The update changes the code to use unity catalog (named sensordata) to store the data.

## Author pre-publish checklist
<!-- Please check check before publishing PR using "x". Remove a column if it's not applicable. -->
- [x] Added test to prove my fix is effective or new feature works
- [x] No PII in logs
- [x] Made corresponding changes to the documentation #978 
- [x] Job runs from ADF for notebook execution work
![image](https://github.com/user-attachments/assets/eff4707c-f284-4ac1-8605-ffaf3953f62e)
![{B7617063-6EBA-443D-B44F-F2A2305AA706}](https://github.com/user-attachments/assets/ea4059e7-0747-42ec-b684-50b074192845)



## Validation steps
Run ADF pipeline to ensure the notebooks execute properly

## Issues Closed or Referenced
- Closes #issue_number
#983 
