### PR TITLE
Update broken-hyperlinks-check.yml

### DIFF
--- a/.github/workflows/broken-hyperlinks-check.yml
+++ b/.github/workflows/broken-hyperlinks-check.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   check-links:
     name: linkspector
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
# Type of PR
- CI-CD changes

## Purpose
Per bug report, ubuntu-latest poses challenges. Works with ubuntu-22.04

## Validation steps
Did linkspector run?
 - If yes, valid.
 - If no, invalid.

Context:
https://github.com/UmbrellaDocs/action-linkspector/issues/25

Fixes issues:
- #1001 