### PR TITLE
Spark Cluster Config Bug Fix

### DIFF
--- a/e2e_samples/parking_sensors/databricks/config/cluster.config.json
+++ b/e2e_samples/parking_sensors/databricks/config/cluster.config.json
@@ -1,8 +1,8 @@
 {
     "cluster_name": "ddo_cluster",
     "autoscale": { "min_workers": 1, "max_workers": 2 },
-    "spark_version": "15.4.x-scala2.12",
-    "autotermination_minutes": 10,
+    "spark_version": "14.3.x-scala2.12",
+    "autotermination_minutes": 30,
     "node_type_id": "Standard_D4as_v5",
     "data_security_mode": "SINGLE_USER",
     "runtime_engine": "PHOTON",


### PR DESCRIPTION
Type of PR
Bug Fix

Code changes
Purpose
The configuration for the databricks cluster should be 14.3.x-scala2.12. The new version was a planned upgrade that was not fully tested.

Does this introduce a breaking change? If yes, details on what can break
This is a bug fix for a break that was introduced.

Issues Closed or Referenced
Closes https://github.com/Azure-Samples/modern-data-warehouse-dataops/issues/1010