### PR TITLE
[Databricks E2E] [BUG] cleanup fix bug with federated credential removal

### DIFF
--- a/e2e_samples/parking_sensors/scripts/clean_up.sh
+++ b/e2e_samples/parking_sensors/scripts/clean_up.sh
@@ -97,7 +97,7 @@ delete_all(){
                 wait_for_process
                 az devops service-endpoint list -o tsv --query "[?contains(name, '$prefix')].id" |
                 xargs -r -I % az devops service-endpoint delete --id % --yes
-                log "Finishing...the clean up of the Service Connections"
+                log "Finished cleaning up Service Connections"
             if [[ -z $DEPLOYMENT_ID ]]
             then
                 log "Deleting service principals that contain '$prefix' in name, created by yourself..."

--- a/e2e_samples/parking_sensors/scripts/common.sh
+++ b/e2e_samples/parking_sensors/scripts/common.sh
@@ -139,8 +139,15 @@ cleanup_federated_credentials() {
     ##Function used in the Clean_up.sh and deploy_azdo_service_connections_azure.sh scripts
     local sc_id=$1
     local spnAppObjId=$(az devops service-endpoint show --id "$sc_id" --org "$AZDO_ORGANIZATION_URL" -p "$AZDO_PROJECT" --query "data.appObjectId" -o tsv)
+    # if the Service connection does not have an associated Service Principal, 
+    # then it means it won't have associated federated credentials
+    if [ -z "$spnAppObjId" ]; then
+        log "Service Principal Object ID not found for Service Connection ID: $sc_id. Skipping federated credential cleanup."
+        return
+    fi
+
     local spnCredlist=$(az ad app federated-credential list --id "$spnAppObjId" --query "[].id" -o json)
-    log "Found existing federated credentials. Deleting..."
+    log "Attempting to delete federated credentials."
 
     # Sometimes the Azure Portal needs a little bit more time to process the information.
     if [ -z "$spnCredlist" ]; then


### PR DESCRIPTION
# Type of PR
<!-- Removed items that do not match with your change. -->

- Code changes

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Fix bug #1046 : `cleanup_federated_credentials.sh` should only attempt to remove credentials when the service connection has an associated service principal, else the script will fail.

## Does this introduce a breaking change? If yes, details on what can break

## Author pre-publish checklist
<!-- Please check check before publishing PR using "x". Remove a column if it's not applicable. -->
- [ ] Added test to prove my fix is effective or new feature works
- [x] No PII in logs
- [ ] Made corresponding changes to the documentation

## Validation steps
<!-- Optional. -->
- run `clean_up.sh` after one successful deployment and make sure no errors are encountered with service connection removal

## Issues Closed or Referenced
<!-- This will automatically close the issue when the PR closes. -->
- Closes #1046 
<!-- this references the issue but does not close with PR. -->
- References #issue_number
