### PR TITLE
[E2E Databricks] - fix clusterId and release folders

### DIFF
--- a/e2e_samples/parking_sensors/.devcontainer/post_create.sh
+++ b/e2e_samples/parking_sensors/.devcontainer/post_create.sh
@@ -12,7 +12,7 @@ pip install -r /workspace/e2e_samples/parking_sensors/src/ddo_transform/requirem
 # This script was reused from the Databricks CLI installation script located here
 # https://github.com/databricks/setup-cli/blob/main/install.sh
 # Check for the latest release version here: https://github.com/databricks/cli/releases
-VERSION="0.233.0"
+VERSION="0.240.0"
 FILE="databricks_cli_$VERSION"
 
 #/home/mdwuser
@@ -91,8 +91,8 @@ echo "tempdir: $tmpdir"
 wget -q https://github.com/databricks/cli/releases/download/v$VERSION/$FILE.zip -O /$tmpdir/${FILE}.zip
 
 # Verify the checksum
-cd /$tmpdir && sha256sum ${FILE}.zip > /$tmpdir/${FILE}.zip.sha256
-cd /$tmpdir 
+cd $tmpdir && sha256sum ${FILE}.zip > $tmpdir/${FILE}.zip.sha256
+cd $tmpdir 
 # Run the sha256sum check
 sha256sum -c ${FILE}.zip.sha256
 
@@ -105,7 +105,7 @@ else
 fi
 
 # Unzip the downloaded file
-unzip -q /$tmpdir/${FILE}.zip #-d /home/mdwuser/databricks
+unzip -q $tmpdir/${FILE}.zip #-d /home/mdwuser/databricks
 
 # Add databricks to path.
 chmod +x ./databricks
@@ -114,7 +114,7 @@ cp ./databricks "$TARGET"
 echo "Installed $("databricks" -v) at $TARGET/databricks."
 
 # Clean up the zip file and checksum
-rm /$tmpdir/${FILE}.zip /$tmpdir/${FILE}.zip.sha256
+rm $tmpdir/${FILE}.zip $tmpdir/${FILE}.zip.sha256
 
 # Clean up temporary directory.
 cd "$OLDPWD"

--- a/e2e_samples/parking_sensors/README.md
+++ b/e2e_samples/parking_sensors/README.md
@@ -165,15 +165,13 @@ There are eight numbered orange boxes describing the sequence from sandbox devel
 2. When changes are complete, developers raise a PR to `main` for review. This automatically kicks-off the PR validation pipeline which runs the unit tests, linting and DACPAC builds.
 3. On PR completion, the commit to `main` will trigger a Build pipeline -- publishing all necessary Build Artifacts.
 4. The completion of a successful Build pipeline will trigger the first stage of the Release pipeline. This deploys the publish build artifacts into the DEV environment, with the exception of Azure Data Factory*.
-5. Developers perform a Manual Publish to the DEV ADF from the collaboration branch (`main`). This updates the ARM templates in in the `adf_publish` branch.
-6. On the successful completion of the first stage, this triggers an Manual Approval Gate**. On Approval, the release pipeline continues with the second stage -- deploying changes to the Staging environment.
-7. Integration tests are run to test changes in the Staging environment.
-8. ***On the successful completion of the second stage, this triggers a second Manual Approval Gate. On Approval, the release pipeline continues with the third stage -- deploying changes to the Production environment.
+5. On the successful completion of the first stage, this triggers an Manual Approval Gate**. On Approval, the release pipeline continues with the second stage -- deploying changes to the Staging environment.
+6. Integration tests are run to test changes in the Staging environment.
+7. ***On the successful completion of the second stage, this triggers a second Manual Approval Gate. On Approval, the release pipeline continues with the third stage -- deploying changes to the Production environment.
 
 Notes:
 
 - This is a simplified Build and Release process for demo purposes based on [Trunk-based development practices](https://trunkbaseddevelopment.com/).
-- *A manual publish is required -- currently, this cannot be automated.
 - **The solution deployment script does not configure Approval Gates at the moment. See [Known Issues, Limitations and Workarounds](#known-issues-limitations-and-workarounds)
 - ***Many organization use dedicated Release Branches (including Microsoft) instead of deploying from `main`. See [Release Flow](https://devblogs.microsoft.com/devops/release-flow-how-we-do-branching-on-the-vsts-team/).
 
@@ -292,7 +290,7 @@ Set up the environment variables as specified, fork the GitHub repository, and l
       - To enable Observability and Monitoring components through code(Observability-as-code), please set enable_monitoring parameter to true in  `arm.parameters` files located in the `infrastructure` folder. This will deploy log analytics workspace to collect monitoring data from key resources, setup an Azure dashboards to monitor key metrics and configure alerts for ADF pipelines.
   
      **Login and Cluster Configuration**
-      
+
       - Ensure that you have completed the configuration for the variables described in the previous section, titled **Configuration: Variables and Login**.
 
 2. **Deploy Azure resources**
@@ -302,11 +300,9 @@ Set up the environment variables as specified, fork the GitHub repository, and l
       - This may take around **~30mins or more** to run end to end. So grab yourself a cup of coffee... ☕ But before you do so keep the following in mind:
         - You might encounter deployment issues if the script attempts to create a Key Vault that conflicts with a previously soft-deleted Key Vault. In such cases, the deployment script may prompt you to confirm the purge of the previously deleted Key Vault.
         - There are 3 points in time where you will need to authenticate to the databricks workspace, before the script continues to run. You will find the following message for the deployment of the dev, stage and production environments. Click the link highlighted in green, consent to authenticate to the databricks workspace and when the workspace opens successfully, return to the deployment windows and press Enter to continue:  ![image](docs/images/databricks_ws.png)
-      - If you encounter an error with `cannot execute: required file not found` verify the line ending settings of your git configuration. This error is likely that the lines in the file are ending with CRLF. Using VSCode, verify that `./deploy.sh` is set to LF only. This can be done using the control pallet and typing `>Change End of Line Sequence`. Also, verify the files in the `scripts` folder are also set to LF only.
+       - If you encounter an error with `cannot execute: required file not found` verify the line ending settings of your git configuration. This error is likely that the lines in the file are ending with CRLF. Using VSCode, verify that `./deploy.sh` is set to LF only. This can be done using the control pallet and typing `>Change End of Line Sequence`. Also, verify the files in the `scripts` folder are also set to LF only.
       - After a successful deployment, you will find `.env.{environment_name}` files containing essential configuration information per environment. See [here](#deployed-resources) for list of deployed resources.
       - Note that if you are using **Dev Container**, you would run the same script but inside the Dev Container terminal.
-   - As part of the deployment script, the Azure DevOps Release Pipeline YAML definition has been updated to point to your Github repository. **Commit and push these changes.**
-      - This will trigger a Build and Release which will fail due to a lacking `adf_publish` branch -- this is expected. This branch will be created once you've setup git integration with your DEV Data Factory and publish a change.
 
 3. **Setup ADF git integration in DEV Data Factory**
 

--- a/e2e_samples/parking_sensors/devops/templates/jobs/deploy-databricks-job.yml
+++ b/e2e_samples/parking_sensors/devops/templates/jobs/deploy-databricks-job.yml
@@ -75,6 +75,14 @@ jobs:
           displayName: 'Set packageWheelName variable'
 
         - script: |
+            # Check if release directory exists.
+            databricks_release_path="/Workspace$DATABRICKS_NOTEBOOK_PATH"
+            if databricks workspace list $databricks_release_path > /dev/null 2>&1; then
+                echo "Folder '$databricks_release_path' already exists."
+            else
+                databricks workspace mkdirs $databricks_release_path
+                echo "Folder '$databricks_release_path' created."
+            fi
             echo "Uploading app libraries to DBFS..."
             echo "Uploading SOURCE whl file: ${WHEEL_FILE_PATH}/${WHEEL_FILE_NAME} to dbfs DESTINATION: ${DBFS_LIBS_PATH}/${WHEEL_FILE_NAME}"
             databricks fs cp --recursive --overwrite "${WHEEL_FILE_PATH}/${WHEEL_FILE_NAME}" "${DBFS_LIBS_PATH}/${WHEEL_FILE_NAME}"

--- a/e2e_samples/parking_sensors/devops/templates/jobs/deploy-databricks-job.yml
+++ b/e2e_samples/parking_sensors/devops/templates/jobs/deploy-databricks-job.yml
@@ -11,8 +11,8 @@ jobs:
     vmImage: 'ubuntu-latest'
   variables:
     pythonVersion: 3.8
-    databricksFile: databricks_cli_0.233.0_linux_amd64
-    databricksCLIVersion: 0.233.0
+    databricksFile: databricks_cli_0.240.0_linux_amd64
+    databricksCLIVersion: 0.240.0
   environment: ${{ parameters.environmentName }}
   strategy:
     runOnce:
@@ -26,17 +26,17 @@ jobs:
           displayName: 'Use Python Version: $(pythonVersion)'
 
         - script: |
-            # Change into temporary directory.
+            # Change into temporary directory
             tmpdir="$(mktemp -d)"
             cd "$tmpdir"
             echo "tempdir: $tmpdir"
             
             # Download release archive.
-            wget -q https://github.com/databricks/cli/releases/download/v$(databricksCLIVersion)/$(databricksFile).zip -O /$tmpdir/$(databricksFile).zip
+            wget -q https://github.com/databricks/cli/releases/download/v$(databricksCLIVersion)/$(databricksFile).zip -O $tmpdir/$(databricksFile).zip
             
             # Verify the checksum
-            cd /$tmpdir && sha256sum $(databricksFile).zip > /$tmpdir/$(databricksFile).zip.sha256
-            cd /$tmpdir 
+            cd $tmpdir && sha256sum $(databricksFile).zip > $tmpdir/$(databricksFile).zip.sha256
+            cd $tmpdir 
             # Run the sha256sum check
             sha256sum -c $(databricksFile).zip.sha256
             
@@ -49,7 +49,7 @@ jobs:
             fi
             
             # Unzip the downloaded file
-            unzip -q /$tmpdir/$(databricksFile).zip
+            unzip -q $tmpdir/$(databricksFile).zip
             
             # Add databricks to path.
             chmod +x ./databricks
@@ -58,7 +58,7 @@ jobs:
             echo "Installed $("databricks" -v) at /usr/local/bin/databricks."
             
             # Clean up the zip file and checksum
-            rm /$tmpdir/$(databricksFile).zip /$tmpdir/$(databricksFile).zip.sha256
+            rm $tmpdir/$(databricksFile).zip $tmpdir/$(databricksFile).zip.sha256
             
             # Clean up temporary directory.
             cd "$OLDPWD"
@@ -86,11 +86,11 @@ jobs:
             echo "Uploading app libraries to DBFS..."
             echo "Uploading SOURCE whl file: ${WHEEL_FILE_PATH}/${WHEEL_FILE_NAME} to dbfs DESTINATION: ${DBFS_LIBS_PATH}/${WHEEL_FILE_NAME}"
             databricks fs cp --recursive --overwrite "${WHEEL_FILE_PATH}/${WHEEL_FILE_NAME}" "${DBFS_LIBS_PATH}/${WHEEL_FILE_NAME}"
-            echo "Uploading notebooks at ${NOTEBOOKS_PATH} to workspace (${DATABRICKS_NOTEBOOK_PATH})..."
-            databricks workspace import "${DATABRICKS_NOTEBOOK_PATH}/00_setup.py" --file "${NOTEBOOKS_PATH}/00_setup.py" --format SOURCE --language PYTHON --overwrite
-            databricks workspace import "${DATABRICKS_NOTEBOOK_PATH}/01_explore.py" --file "${NOTEBOOKS_PATH}/01_explore.py" --format SOURCE --language PYTHON --overwrite
-            databricks workspace import "${DATABRICKS_NOTEBOOK_PATH}/02_standardize.py" --file "${NOTEBOOKS_PATH}/02_standardize.py" --format SOURCE --language PYTHON --overwrite
-            databricks workspace import "${DATABRICKS_NOTEBOOK_PATH}/03_transform.py" --file "${NOTEBOOKS_PATH}/03_transform.py" --format SOURCE --language PYTHON --overwrite
+            echo "Uploading notebooks at ${NOTEBOOKS_PATH} to workspace (${databricks_release_path})..."
+            databricks workspace import "${databricks_release_path}/00_setup" --file "${NOTEBOOKS_PATH}/00_setup.py" --format SOURCE --language PYTHON --overwrite
+            databricks workspace import "${databricks_release_path}/01_explore" --file "${NOTEBOOKS_PATH}/01_explore.py" --format SOURCE --language PYTHON --overwrite
+            databricks workspace import "${databricks_release_path}/02_standardize" --file "${NOTEBOOKS_PATH}/02_standardize.py" --format SOURCE --language PYTHON --overwrite
+            databricks workspace import "${databricks_release_path}/03_transform" --file "${NOTEBOOKS_PATH}/03_transform.py" --format SOURCE --language PYTHON --overwrite
 
             # Create JSON file for library installation
             temp_dir=$(mktemp -d)

--- a/e2e_samples/parking_sensors/devops/templates/jobs/deploy-databricks-job.yml
+++ b/e2e_samples/parking_sensors/devops/templates/jobs/deploy-databricks-job.yml
@@ -75,6 +75,10 @@ jobs:
           displayName: 'Set packageWheelName variable'
 
         - script: |
+            set -o errexit
+            set -o pipefail
+            set -o nounset
+
             # Check if release directory exists.
             databricks_release_path="/Workspace$DATABRICKS_NOTEBOOK_PATH"
             if databricks workspace list $databricks_release_path > /dev/null 2>&1; then
@@ -83,6 +87,15 @@ jobs:
                 databricks workspace mkdirs $databricks_release_path
                 echo "Folder '$databricks_release_path' created."
             fi
+
+            echo "Creating folder in ADLS..."
+            relative_path=${DBFS_LIBS_PATH#dbfs:/mnt/}
+            fs_name="$(cut -d '/' -f 1 <<< $relative_path)"
+            fs_folder_path="/$(cut -d '/' -f 2- <<< $relative_path)"
+            stg_account_name=$(databricks secrets get-secret storage_scope datalakeAccountName | jq -r .value | base64 -d)
+            stg_account_key=$(databricks secrets get-secret storage_scope datalakeKey | jq -r .value | base64 -d)
+            az storage fs directory create -n "$fs_folder_path" -f $fs_name --account-name $stg_account_name --account-key $stg_account_key -o none
+
             echo "Uploading app libraries to DBFS..."
             echo "Uploading SOURCE whl file: ${WHEEL_FILE_PATH}/${WHEEL_FILE_NAME} to dbfs DESTINATION: ${DBFS_LIBS_PATH}/${WHEEL_FILE_NAME}"
             databricks fs cp --recursive --overwrite "${WHEEL_FILE_PATH}/${WHEEL_FILE_NAME}" "${DBFS_LIBS_PATH}/${WHEEL_FILE_NAME}"
@@ -118,3 +131,4 @@ jobs:
             NOTEBOOKS_PATH: $(Pipeline.Workspace)/ciartifacts/databricks/notebooks
             DATABRICKS_NOTEBOOK_PATH: $(databricksNotebookPath)
           displayName: 'Deploy notebooks and packages'
+ 

--- a/e2e_samples/parking_sensors/scripts/configure_databricks.sh
+++ b/e2e_samples/parking_sensors/scripts/configure_databricks.sh
@@ -143,7 +143,7 @@ databricks libraries install --json @$json_file
 
 # Creates a Job to setup workspace
 log "Creating a job to setup the workspace..."
-notebook_path="${DATABRICKS_RELEASE_FOLDER}/00_setup.py"
+notebook_path="${DATABRICKS_RELEASE_FOLDER}/00_setup"
 log "notebook_path: ${notebook_path}"
 json_file_config="./databricks/config/job.setup.config.json"
 cat <<EOF > $json_file_config

--- a/e2e_samples/parking_sensors/scripts/configure_databricks.sh
+++ b/e2e_samples/parking_sensors/scripts/configure_databricks.sh
@@ -51,10 +51,10 @@ databricks secrets create-scope --json "{\"scope\": \"$scope_name\", \"scope_bac
 log "Uploading notebooks..."
 databricks workspace mkdirs "$DATABRICKS_RELEASE_FOLDER"
 log "$ENV_NAME releases folder: $DATABRICKS_RELEASE_FOLDER"
-databricks workspace import "$DATABRICKS_RELEASE_FOLDER/00_setup.py" --file "./databricks/notebooks/00_setup.py" --format SOURCE --language PYTHON --overwrite
-databricks workspace import "$DATABRICKS_RELEASE_FOLDER/01_explore.py" --file "./databricks/notebooks/01_explore.py" --format SOURCE --language PYTHON --overwrite
-databricks workspace import "$DATABRICKS_RELEASE_FOLDER/02_standardize.py" --file "./databricks/notebooks/02_standardize.py" --format SOURCE --language PYTHON --overwrite
-databricks workspace import "$DATABRICKS_RELEASE_FOLDER/03_transform.py" --file "./databricks/notebooks/03_transform.py" --format SOURCE --language PYTHON --overwrite
+databricks workspace import "$DATABRICKS_RELEASE_FOLDER/00_setup" --file "./databricks/notebooks/00_setup.py" --format SOURCE --language PYTHON --overwrite
+databricks workspace import "$DATABRICKS_RELEASE_FOLDER/01_explore" --file "./databricks/notebooks/01_explore.py" --format SOURCE --language PYTHON --overwrite
+databricks workspace import "$DATABRICKS_RELEASE_FOLDER/02_standardize" --file "./databricks/notebooks/02_standardize.py" --format SOURCE --language PYTHON --overwrite
+databricks workspace import "$DATABRICKS_RELEASE_FOLDER/03_transform" --file "./databricks/notebooks/03_transform.py" --format SOURCE --language PYTHON --overwrite
 
 # Define suitable VM for DB cluster
 file_path="./databricks/config/cluster.config.json"

--- a/e2e_samples/parking_sensors/scripts/configure_databricks.sh
+++ b/e2e_samples/parking_sensors/scripts/configure_databricks.sh
@@ -24,7 +24,6 @@ set -o nounset
 #
 # DATABRICKS_HOST
 # DATABRICKS_TOKEN - this needs to be a Microsoft Entra ID user token (not PAT token or Microsoft Entra ID application token that belongs to a service principal)
-# DATABRICKS_KV_TOKEN
 # KEYVAULT_RESOURCE_ID
 # KEYVAULT_DNS_NAME
 # KEYVAULT_NAME
@@ -34,15 +33,6 @@ set -o nounset
 . ./scripts/common.sh
 
 log "Configuring Databricks workspace."
-
-# Create the databrickscnf file
-cat <<EOL > ~/.databrickscnf
-[DEFAULT]
-host=$DATABRICKS_HOST
-token=$DATABRICKS_KV_TOKEN
-EOL
-
-cat ~/.databrickscnf
 
 # Create secret scope, if not exists
 scope_name="storage_scope"

--- a/e2e_samples/parking_sensors/scripts/deploy_azdo_variables.sh
+++ b/e2e_samples/parking_sensors/scripts/deploy_azdo_variables.sh
@@ -40,6 +40,7 @@ set -o nounset
 # AZURE_LOCATION
 # RESOURCE_GROUP_NAME
 # KV_URL
+# KV_NAME
 # DATABRICKS_HOST
 # DATABRICKS_TOKEN
 # DATABRICKS_WORKSPACE_RESOURCE_ID
@@ -71,7 +72,7 @@ else
     databricksNotebookPath='/releases/$(Build.BuildId)'
 fi
 
-databricksClusterId="$DATABRICKS_CLUSTER_ID"
+databricksClusterId=$(az keyvault secret show --name "databricksClusterId" --vault-name "$KV_NAME" --query "value" -o tsv)
 
 # Create vargroup
 vargroup_name="${PROJECT}-release-$ENV_NAME"
@@ -79,7 +80,7 @@ if vargroup_id=$(az pipelines variable-group list -o json | jq -r -e --arg vg_na
     log "Variable group: $vargroup_name already exists. Deleting..." "info"
     az pipelines variable-group delete --id "$vargroup_id" -y  -o none
 fi
-log "Creating variable group: $vargroup_name"
+log "Creating variable group: $vargroup_name" "info"
 az pipelines variable-group create \
     --name "$vargroup_name" \
     --authorize "true" \
@@ -99,7 +100,7 @@ if vargroup_secrets_id=$(az pipelines variable-group list -o json | jq -r -e --a
     log "Variable group: $vargroup_secrets_name already exists. Deleting..." "info"
     az pipelines variable-group delete --id "$vargroup_secrets_id" -y -o none
 fi
-log "Creating variable group: $vargroup_secrets_name"
+log "Creating variable group: $vargroup_secrets_name" "info"
 vargroup_secrets_id=$(az pipelines variable-group create \
     --name "$vargroup_secrets_name" \
     --authorize "true" \

--- a/e2e_samples/parking_sensors/scripts/deploy_azdo_variables.sh
+++ b/e2e_samples/parking_sensors/scripts/deploy_azdo_variables.sh
@@ -65,8 +65,8 @@ if [ "$ENV_NAME" == "dev" ]
 then 
     # In DEV, we fix the path to "dev" folder  to simplify as this is manual publish DEV ADF.
     # In other environments, the ADF release pipeline overwrites these automatically.
-    databricksDbfsLibPath="dbfs:/mnt/datalake/sys/databricks/libs/dev/"
-    databricksNotebookPath='/releases/dev/'
+    databricksDbfsLibPath="dbfs:/mnt/datalake/sys/databricks/libs/dev"
+    databricksNotebookPath='/releases/dev'
 else
     databricksDbfsLibPath='dbfs:/mnt/datalake/sys/databricks/libs/$(Build.BuildId)'
     databricksNotebookPath='/releases/$(Build.BuildId)'

--- a/e2e_samples/parking_sensors/scripts/deploy_infrastructure.sh
+++ b/e2e_samples/parking_sensors/scripts/deploy_infrastructure.sh
@@ -264,19 +264,7 @@ az keyvault secret set --vault-name "$kv_name" --name "databricksDomain" --value
 az keyvault secret set --vault-name "$kv_name" --name "databricksToken" --value "$databricks_token" -o none
 az keyvault secret set --vault-name "$kv_name" --name "databricksWorkspaceResourceId" --value "$databricks_workspace_resource_id" -o none
 
-# Configure databricks (KeyVault-backed Secret scope, mount to storage via SP, databricks tables, cluster)
-# NOTE: must use Microsoft Entra access token, not PAT token
-DATABRICKS_TOKEN=$databricks_aad_token \
-DATABRICKS_HOST=$databricks_host \
-KEYVAULT_DNS_NAME=$kv_dns_name \
-KEYVAULT_NAME=$kv_name \
-USER_NAME=$kv_owner_name \
-AZURE_LOCATION=$AZURE_LOCATION \
-KEYVAULT_RESOURCE_ID=$(echo "$arm_output" | jq -r '.properties.outputs.keyvault_resource_id.value') \
-    bash -c "./scripts/configure_databricks.sh"
-
-####################
-# DATA FACTORY
+# Setup the release folder
 if [ "$ENV_NAME" == "dev" ]; then
     databricks_release_folder="/releases/${ENV_NAME}"
 else  
@@ -286,6 +274,21 @@ databricks_folder_name_standardize="$databricks_release_folder/02_standardize.py
 databricks_folder_name_transform="$databricks_release_folder/03_transform.py"
 log "databricks_folder_name_standardize: ${databricks_folder_name_standardize}" "info"
 log "databricks_folder_name_transform: ${databricks_folder_name_transform}" "info"
+
+# Configure databricks (KeyVault-backed Secret scope, mount to storage via SP, databricks tables, cluster)
+# NOTE: must use Microsoft Entra access token, not PAT token
+DATABRICKS_TOKEN=$databricks_aad_token \
+DATABRICKS_HOST=$databricks_host \
+KEYVAULT_DNS_NAME=$kv_dns_name \
+KEYVAULT_NAME=$kv_name \
+USER_NAME=$kv_owner_name \
+AZURE_LOCATION=$AZURE_LOCATION \
+DATABRICKS_RELEASE_FOLDER=$databricks_release_folder \
+KEYVAULT_RESOURCE_ID=$(echo "$arm_output" | jq -r '.properties.outputs.keyvault_resource_id.value') \
+    bash -c "./scripts/configure_databricks.sh"
+
+####################
+# DATA FACTORY
 
 log "Updating Data Factory LinkedService to point to newly deployed resources (KeyVault and DataLake)."
 # Create a copy of the ADF dir into a .tmp/ folder.

--- a/e2e_samples/parking_sensors/scripts/deploy_infrastructure.sh
+++ b/e2e_samples/parking_sensors/scripts/deploy_infrastructure.sh
@@ -267,7 +267,6 @@ az keyvault secret set --vault-name "$kv_name" --name "databricksWorkspaceResour
 # Configure databricks (KeyVault-backed Secret scope, mount to storage via SP, databricks tables, cluster)
 # NOTE: must use Microsoft Entra access token, not PAT token
 DATABRICKS_TOKEN=$databricks_aad_token \
-DATABRICKS_KV_TOKEN=$databricks_token \
 DATABRICKS_HOST=$databricks_host \
 KEYVAULT_DNS_NAME=$kv_dns_name \
 KEYVAULT_NAME=$kv_name \


### PR DESCRIPTION
# Type of PR
- Code changes

## Purpose
- This PR is fixing 2 issues: 
1) Saving the cluster Id when first created in KV and accessing it on case of a second run of the deployment is triggered
2) Fixing the releases folder - at deployment time and in the release pipeline time

## Does this introduce a breaking change? If yes, details on what can break
No.

## Author pre-publish checklist
- [ ] Added test to prove my fix is effective or new feature works: fully testes the e2e sample from deploy to release managament
- [X] No PII in logs
- [ ] Made corresponding changes to the documentation: not necessary

## Validation steps
- Deploy the sample and verify that:
1) the releases folder is created for dev on databricks on Workspace/releases/dev
2)  the releases folder is created for stg and prod on databricks on Workspace/releases/setup_release
- Run the CI/CD pipeline and verify that
1) the releases folder is updated for dev on databricks on Workspace/releases/dev
2)  the releases folder is updated for stg and prod on databricks on Workspace/releases/{release_number}
and that all the notebooks were succesfully copied.

- For the cluster ID - redeploy the sample. Check that the clusterId value was sucessfully saved in KV and that the cluster ID is not empty during the deployment run. You should be able to see on the Log: Cluster ID: <valid_non_empty_value>

## Issues Closed or Referenced
- Closes #1062 
