### PR TITLE
fix: py extension on adf pipeline

### DIFF
--- a/e2e_samples/parking_sensors/scripts/deploy_infrastructure.sh
+++ b/e2e_samples/parking_sensors/scripts/deploy_infrastructure.sh
@@ -270,8 +270,8 @@ if [ "$ENV_NAME" == "dev" ]; then
 else  
     databricks_release_folder="/releases/setup_release"
 fi
-databricks_folder_name_standardize="$databricks_release_folder/02_standardize.py"
-databricks_folder_name_transform="$databricks_release_folder/03_transform.py"
+databricks_folder_name_standardize="$databricks_release_folder/02_standardize"
+databricks_folder_name_transform="$databricks_release_folder/03_transform"
 log "databricks_folder_name_standardize: ${databricks_folder_name_standardize}" "info"
 log "databricks_folder_name_transform: ${databricks_folder_name_transform}" "info"
 


### PR DESCRIPTION
# Type of PR
- Code changes


## Purpose
- Remove .py extension from pipeline definition

## Does this introduce a breaking change? If yes, details on what can break

## Author pre-publish checklist
- [ ] Added test to prove my fix is effective or new feature works
- [X] No PII in logs
- [ ] Made corresponding changes to the documentation

## Validation steps
- Deploy - verify the ADF pipeline points to the correct notebook (not .py extension)

## Issues Closed or Referenced
- Closes #1071
- References #1062  
