### PR TITLE
[E2E Databricks] - fix: PAT guidance on ReadMe

### DIFF
--- a/e2e_samples/parking_sensors/README.md
+++ b/e2e_samples/parking_sensors/README.md
@@ -271,7 +271,7 @@ Set up the environment variables as specified, fork the GitHub repository, and l
      - **AZDO_PROJECT** - Target Azure DevOps project where Azure Pipelines and Variable groups will be deployed
      - **AZDO_ORGANIZATION_URL** - Target Azure DevOps Organization of Azure DevOps project in this form `https://dev.azure.com/<organization>/`. Must be in the same tenant as $TENANT_ID
      - **GITHUB_REPO** - Name of your forked github repo in this form `<my_github_handle>/<repo>`. (ei. "devlace/mdw-dataops-import")
-     - **GITHUB_PAT_TOKEN** - a Github PAT token. Generate them [here](https://github.com/settings/tokens). The token is needed to connect to the GitHub repository. When generating a token use a `fine-grained` token, select your repository and under repository permissions select Read access to Content and Webhooks. Under Account permissions select read access to Email.
+     - **GITHUB_PAT_TOKEN** - a Github PAT token. Generate them [here](https://github.com/settings/tokens). The token is needed to connect to the GitHub repository. When generating a token use a `fine-grained` token, select your repository and under repository permissions select Read access to Content and Read and Write access to Webhooks. Under Account permissions select read access to Email.
 
      Optionally, set the following environment variables:
 


### PR DESCRIPTION
# Type of PR
- Documentation changes

## Purpose
- Correcting guidance on fine grained tokens

## Does this introduce a breaking change? If yes, details on what can break

## Author pre-publish checklist
- [ ] Added test to prove my fix is effective or new feature works
- [ ] No PII in logs
- [ ] Made corresponding changes to the documentation

## Validation steps
- Check on main ReadMe that the guidance for permissions for the PAT  fine grained tokens include read and write into Webhooks

## Issues Closed or Referenced
- Closes #1095 
