### PR TITLE
SQL Server + DB deployment

### DIFF
--- a/e2e_samples/unstructured_data/infrastructure/main.bicep
+++ b/e2e_samples/unstructured_data/infrastructure/main.bicep
@@ -9,6 +9,11 @@ param keyvault_name string
 param enable_keyvault_soft_delete bool = true
 param enable_keyvault_purge_protection bool = true
 // param entra_admin_login string
+param sql_server_name string
+param sql_db_name string
+param aad_group_name string
+param aad_group_object_id string
+param ip_address string
 
 module databricks './modules/databricks.bicep' = {
   name: 'databricks_deploy_${deployment_id}'
@@ -45,6 +50,18 @@ module keyvault './modules/keyvault.bicep' = {
   }
 }
 
+module sql './modules/sql.bicep' = {
+  name: 'sql_deploy_${deployment_id}'
+  params: {
+    sql_server_name: sql_server_name
+    sql_db_name: sql_db_name
+    env: env
+    location: location
+    aad_group_name: aad_group_name
+    aad_group_object_id: aad_group_object_id
+    ip_address: ip_address
+  }
+}
 
 // module appinsights './modules/appinsights.bicep' = {
 //   name: 'appinsights_deploy_${deployment_id}'

--- a/e2e_samples/unstructured_data/infrastructure/modules/sql.bicep
+++ b/e2e_samples/unstructured_data/infrastructure/modules/sql.bicep
@@ -1,0 +1,84 @@
+// https://learn.microsoft.com/en-us/azure/templates/microsoft.sql/servers
+// https://learn.microsoft.com/en-us/azure/templates/microsoft.sql/servers/databases
+@description('The environment for the deployment.')
+@allowed([
+  'dev'
+  'stg'
+  'prod'
+])
+param env string
+
+@description('Location for all resources.')
+param location string = resourceGroup().location
+
+@description('The name of the SQL logical server.')
+param sql_server_name string
+
+@description('The name of the SQL Database.')
+param sql_db_name string
+
+@description('The AAD group name granted admin access to the SQL Server.')
+param aad_group_name string
+
+@description('The AAD group object ID granted admin access to the SQL Server.')
+param aad_group_object_id string
+
+@description('IP address to whitelist.')
+param ip_address string
+
+resource sql_server 'Microsoft.Sql/servers@2022-05-01-preview' = {
+  name: sql_server_name
+  location: location
+  tags: {
+    DisplayName: 'SQL Server'
+    Environment: env
+  }
+  properties: {
+    administrators: {
+      administratorType: 'ActiveDirectory'
+      azureADOnlyAuthentication: true
+      login: aad_group_name
+      sid: aad_group_object_id
+      tenantId: subscription().tenantId
+    }
+  }
+}
+
+resource sql_db 'Microsoft.Sql/servers/databases@2022-05-01-preview' = {
+  parent: sql_server
+  name: sql_db_name
+  location: location
+  sku: {
+    name: 'Standard'
+    tier: 'Standard'
+  }
+}
+
+resource sqlServerAdministrator 'Microsoft.Sql/servers/administrators@2024-05-01-preview' = {
+  parent: sql_server
+  name: 'ActiveDirectory'
+  properties: {
+    administratorType: 'ActiveDirectory'
+    login: aad_group_name
+    sid: aad_group_object_id
+    tenantId: subscription().tenantId
+  }
+}
+
+resource aadAuth 'Microsoft.Sql/servers/azureADOnlyAuthentications@2024-05-01-preview' = {
+  name: 'Default'
+  parent: sql_server
+  properties: {
+    azureADOnlyAuthentication: true
+  }
+}
+
+// Firewall
+resource DB_Firewall 'Microsoft.Sql/servers/firewallRules@2021-11-01-preview' = {
+  name: 'Database server firewall'
+  parent: sql_server
+  properties: {
+    startIpAddress: ip_address
+    endIpAddress: ip_address
+  }
+}


### PR DESCRIPTION
# Type of PR
<!-- Removed items that do not match with your change. -->

- Code changes

## Purpose
This code adds the SQL Server + DB bicep modules and adds a security group containing the `deploy.sh` executor as an admin of the SQL Server.

A firewall is added as a child of the SQL server, allowing the end user to edit the database.

## Does this introduce a breaking change? If yes, details on what can break

## Author pre-publish checklist
- [ ] Added test to prove my fix is effective or new feature works
- [x] No PII in logs
- [ ] Made corresponding changes to the documentation

## Validation steps
1. Follow deployment steps listed at `e2e_samples/unstructured_data/README.md`.
2. Validate that SQL Server and DB have been created under the listed resource group and that creates/reads/updates can be executed upon.

## Issues Closed or Referenced
- Closes #1034 
