### PR TITLE
Updates infra and storage utils to use connection string

### DIFF
--- a/e2e_samples/unstructured_data/deploy.sh
+++ b/e2e_samples/unstructured_data/deploy.sh
@@ -336,6 +336,7 @@ KEYVAULT_DNS_NAME=$kv_dns_name \
 USER_NAME=$kv_owner_name \
 AZURE_LOCATION=$AZURE_LOCATION \
 KEYVAULT_RESOURCE_ID=$(echo "$arm_output" | jq -r '.properties.outputs.keyvault_resource_id.value') \
+STORAGE_CONN_STRING=$(echo "$arm_output" | jq -r '.properties.outputs.storage_conn_string.value') \
     bash -c "./infrastructure/configure_databricks.sh"
 
 ####################

--- a/e2e_samples/unstructured_data/infrastructure/configure_databricks.sh
+++ b/e2e_samples/unstructured_data/infrastructure/configure_databricks.sh
@@ -28,6 +28,7 @@ set -o nounset
 # KEYVAULT_DNS_NAME
 # USER_NAME
 # AZURE_LOCATION
+# STORAGE_CONN_STRING
 
 . ./infrastructure/common.sh
 
@@ -43,7 +44,12 @@ if [[ ! -z $(databricks secrets list-scopes | grep "$scope_name") ]]; then
 fi
 
 # Create secret scope
-databricks secrets create-scope --json "{\"scope\": \"$scope_name\", \"scope_backend_type\": \"AZURE_KEYVAULT\", \"backend_azure_keyvault\": { \"resource_id\": \"$KEYVAULT_RESOURCE_ID\", \"dns_name\": \"$KEYVAULT_DNS_NAME\" } }"
+databricks secrets create-scope $scope_name --scope-backend-type "DATABRICKS"
+# TODO: Azure KV backed scope is READONLY for databricks, can update the script to add to KV directly later
+# databricks secrets create-scope --json "{\"scope\": \"$scope_name\", \"scope_backend_type\": \"AZURE_KEYVAULT\", \"backend_azure_keyvault\": { \"resource_id\": \"$KEYVAULT_RESOURCE_ID\", \"dns_name\": \"$KEYVAULT_DNS_NAME\" } }"
+
+# Creating databricks scoped secret
+databricks secrets put-secret $scope_name "storage-conn-string" --string-value "$STORAGE_CONN_STRING"
 
 # Upload notebooks
 log "Uploading notebooks..."

--- a/e2e_samples/unstructured_data/infrastructure/main.bicep
+++ b/e2e_samples/unstructured_data/infrastructure/main.bicep
@@ -152,6 +152,8 @@ module loganalytics './modules/log_analytics.bicep' = if (enable_monitoring) {
 
 
 output storage_account_name string = storage.outputs.storage_account_name
+output storage_conn_string string = storage.outputs.storage_conn_string
+
 output databricks_output object = databricks.outputs.databricks_output
 output databricks_id string = databricks.outputs.databricks_id
 output appinsights_name string = appinsights.outputs.appinsights_name

--- a/e2e_samples/unstructured_data/infrastructure/modules/storage.bicep
+++ b/e2e_samples/unstructured_data/infrastructure/modules/storage.bicep
@@ -38,6 +38,8 @@ resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' = {
       bypass: 'AzureServices'
       defaultAction: 'Allow'
     }
+    allowBlobPublicAccess: true // TODO: Check if this is necessary
+    allowSharedKeyAccess: true
     supportsHttpsTrafficOnly: true
     encryption: {
       services: {
@@ -70,3 +72,6 @@ resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' = {
 // Outputs
 @description('The name of the storage account.')
 output storage_account_name string = storage.name
+
+@description('The account connection string')
+output storage_conn_string string = 'DefaultEndpointsProtocol=https;AccountName=${storage.name};AccountKey=${listKeys(storage.id, storage.apiVersion).keys[0].value};EndpointSuffix=${environment().suffixes.storage}'

--- a/e2e_samples/unstructured_data/infrastructure/modules/storage.bicep
+++ b/e2e_samples/unstructured_data/infrastructure/modules/storage.bicep
@@ -38,7 +38,7 @@ resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' = {
       bypass: 'AzureServices'
       defaultAction: 'Allow'
     }
-    allowBlobPublicAccess: true // TODO: Check if this is necessary
+    allowBlobPublicAccess: true
     allowSharedKeyAccess: true
     supportsHttpsTrafficOnly: true
     encryption: {

--- a/e2e_samples/unstructured_data/scripts/run_experiments.ipynb
+++ b/e2e_samples/unstructured_data/scripts/run_experiments.ipynb
@@ -57,7 +57,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "connection_string = dbutils.secrets.get(scope=\"storage_scope\", key=\"storage-conn-string\")\n",
+    "connection_string = dbutils.secrets.get(scope=\"storage_scope\", key=\"storage-conn-string\") # noqa: F821\n",
     "os.environ[\"AZURE_STORAGE_CONNECTION_STRING\"] = connection_string\n",
     "\n",
     "if variants is None:\n",

--- a/e2e_samples/unstructured_data/scripts/run_experiments.ipynb
+++ b/e2e_samples/unstructured_data/scripts/run_experiments.ipynb
@@ -57,8 +57,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "connection_string = dbutils.secrets.get(scope=\"storage_scope\", key=\"storage-conn-string\")\n",
+    "os.environ[\"AZURE_STORAGE_CONNECTION_STRING\"] = connection_string\n",
+    "\n",
     "if variants is None:\n",
-    "    variants = [\"total-revenue/1.yaml\"]\n",
+    "    variants = [\"total_revenue/1.yaml\"]\n",
     "\n",
     "telemetry = telemetry.upper() if telemetry is not None else None\n",
     "configure_telemetry(telemetry)\n",

--- a/e2e_samples/unstructured_data/scripts/run_experiments.ipynb
+++ b/e2e_samples/unstructured_data/scripts/run_experiments.ipynb
@@ -57,7 +57,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "connection_string = dbutils.secrets.get(scope=\"storage_scope\", key=\"storage-conn-string\") # noqa: F821\n",
+    "connection_string = dbutils.secrets.get(scope=\"storage_scope\", key=\"storage-conn-string\")  # noqa: F821\n",
     "os.environ[\"AZURE_STORAGE_CONNECTION_STRING\"] = connection_string\n",
     "\n",
     "if variants is None:\n",
@@ -65,6 +65,7 @@
     "\n",
     "telemetry = telemetry.upper() if telemetry is not None else None\n",
     "configure_telemetry(telemetry)\n",
+    "\n",
     "\n",
     "data_path = RepoPaths.data_path(data_filename)\n",
     "\n",

--- a/e2e_samples/unstructured_data/src/common/azure_storage_utils.py
+++ b/e2e_samples/unstructured_data/src/common/azure_storage_utils.py
@@ -1,7 +1,5 @@
-from azure.identity import DefaultAzureCredential
 from azure.storage.blob import BlobServiceClient
 
 
-def get_blob_service_client(account_url: str) -> BlobServiceClient:
-    credential = DefaultAzureCredential()
-    return BlobServiceClient(account_url=account_url, credential=credential)
+def get_blob_service_client(conn_string: str) -> BlobServiceClient:
+    return BlobServiceClient.from_connection_string(conn_string)

--- a/e2e_samples/unstructured_data/src/experiments/llm_citation_generator/main.py
+++ b/e2e_samples/unstructured_data/src/experiments/llm_citation_generator/main.py
@@ -65,12 +65,15 @@ class LLMCitationGenerator:
                 raise KeyError("'db_question_id' is a required argument when Citation DB is enabled.")
 
         self.blob_account_url = os.environ["AZURE_STORAGE_ACCOUNT_URL"]
+        self.storage_conn_str = os.environ["AZURE_STORAGE_CONNECTION_STRING"]
         self.llm_creds = OAICredentials.from_env()
 
     def __call__(self, submission_folder: str, **kwargs: Any) -> dict:
         output: dict = {}
         llm = AzureOpenAILLM(creds=self.llm_creds)
-        blob_service_client = get_blob_service_client(account_url=self.blob_account_url)
+        blob_service_client = get_blob_service_client(conn_string=self.storage_conn_str)
+        logger.debug(f"Connecting to blob storage at {self.blob_account_url}")
+        logger.debug(f"Using blob storage connection string: {self.storage_conn_str}")
         docs = analyze_submission_folder(
             blob_service_client=blob_service_client,
             folder_name=submission_folder,
@@ -178,7 +181,7 @@ if __name__ == "__main__":
 
     # update values as needed
     submission_folder = "F24Q3"
-    variants = ["total-revenue/1.yaml"]
+    variants = ["total_revenue/1.yaml"]
     write_to_file = False
 
     run_id = new_run_id()

--- a/e2e_samples/unstructured_data/src/experiments/llm_citation_generator/main.py
+++ b/e2e_samples/unstructured_data/src/experiments/llm_citation_generator/main.py
@@ -64,7 +64,6 @@ class LLMCitationGenerator:
             if self.db_question_id is None:
                 raise KeyError("'db_question_id' is a required argument when Citation DB is enabled.")
 
-        self.blob_account_url = os.environ["AZURE_STORAGE_ACCOUNT_URL"]
         self.storage_conn_str = os.environ["AZURE_STORAGE_CONNECTION_STRING"]
         self.llm_creds = OAICredentials.from_env()
 
@@ -72,8 +71,6 @@ class LLMCitationGenerator:
         output: dict = {}
         llm = AzureOpenAILLM(creds=self.llm_creds)
         blob_service_client = get_blob_service_client(conn_string=self.storage_conn_str)
-        logger.debug(f"Connecting to blob storage at {self.blob_account_url}")
-        logger.debug(f"Using blob storage connection string: {self.storage_conn_str}")
         docs = analyze_submission_folder(
             blob_service_client=blob_service_client,
             folder_name=submission_folder,


### PR DESCRIPTION
# Type of PR
- Documentation changes
- Code changes

## Purpose
We want to use connection strings stored in databricks scoped secrets to connect to Azure Storage Accounts.

## Author pre-publish checklist
- [ ] Added test to prove my fix is effective or new feature works
- [ ] Made corresponding changes to the documentation

## Validation steps
Run deploy, since the deploy script copies from the main kraken/unstructured branch, you'll either have to update that to this one or make the changes yourself. Additionally, you'll have to update the created storage account to have the specified folder structure, ie. msft-quarterly-earnings/josh-test/pressrelease.pdf. Depending on how many documents you add, you'll also have to change the test-data.jsonl

## Issues Closed or Referenced
- Handles the storage part of #1131 
