### PR TITLE
Add template and questions creation scripts

### DIFF
--- a/e2e_samples/unstructured_data/scripts/create_db_question.py
+++ b/e2e_samples/unstructured_data/scripts/create_db_question.py
@@ -1,0 +1,60 @@
+# usage:
+# python ./scripts/create_db_question.py --template-id <template-id> --prefix <question-prefix> --text <question-text> # noqa: E501
+# python ./scripts/create_db_question.py -i 1 -p 3 -t "test question 3"
+
+
+if __name__ == "__main__":
+    import argparse
+    import logging
+
+    from common.citation_db import (
+        CitationDBConfig,
+        CitationDBOptions,
+        create_question,
+        create_template_question_lockfile,
+        get_conn,
+    )
+    from common.config_utils import EnvFetcher
+    from common.logging import get_logger
+
+    logging.basicConfig()
+    logger = get_logger(__name__)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-i", "--template-id", required=True, help="The template_id of the template")
+    parser.add_argument("-p", "--prefix", required=True, help="The prefix for the question")
+    parser.add_argument("-t", "--text", required=True, help="The text of the question")
+    parser.add_argument(
+        "-c", "--creator", default="llm-citation-generator", help="The creator of the template and questions"
+    )
+    args = parser.parse_args()
+    template_id = args.template_id
+    prefix = args.prefix
+    text = args.text
+    creator = args.creator
+    config = CitationDBConfig.fetch(fetcher=EnvFetcher(), options=CitationDBOptions(creator=creator))
+
+    conn = None
+    cursor = None
+    try:
+        conn = get_conn(config.conn_str)
+        cursor = conn.cursor()
+        question_id = create_question(
+            cursor=cursor,
+            conn=conn,
+            template_id=template_id,
+            prefix=prefix,
+            text=text,
+            creator=config.options.creator,
+        )
+        logger.info(f"Created question with id: {question_id}")
+        path = create_template_question_lockfile(
+            cursor=cursor,
+            template_id=template_id,
+        )
+        logger.info(f"Updated template question lockfile at path {path}")
+    finally:
+        if cursor:
+            cursor.close()
+        if conn:
+            conn.close()

--- a/e2e_samples/unstructured_data/scripts/populate_db.py
+++ b/e2e_samples/unstructured_data/scripts/populate_db.py
@@ -1,0 +1,35 @@
+# usage:
+# python ./scripts/create_db_template.py --name <template-name> --creator <creator>
+# python ./scripts/create_db_template.py -n test-template --creator llm-citation-generator
+
+
+if __name__ == "__main__":
+    import argparse
+    import logging
+
+    from common.citation_db import CitationDBConfig, CitationDBOptions, DBQuestion, create_template_and_questions
+    from common.config_utils import EnvFetcher
+    from common.logging import get_logger
+
+    logging.basicConfig()
+    logger = get_logger(__name__)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-n", "--name", default="template-1", help="The name of the template to create")
+    parser.add_argument("-c", "--creator", default="llm-citation-generator", help="The name of the template to create")
+    args = parser.parse_args()
+    template_name = args.name
+    creator = args.creator
+
+    config = CitationDBConfig.fetch(fetcher=EnvFetcher(), options=CitationDBOptions(creator=creator))
+    questions = [
+        DBQuestion(
+            prefix="1",
+            text="What was the company’s revenue for this quarter of this Fiscal Year?",
+        ),
+        DBQuestion(prefix="2", text="What are the earnings per share (EPS) for this quarter?"),
+    ]
+
+    path, templates_id = create_template_and_questions(config=config, template_name=template_name, questions=questions)
+    logger.info(f"Updated template question lockfile at path {path}")
+    logger.info(f"Created template {template_name} with id: {templates_id}")

--- a/e2e_samples/unstructured_data/scripts/populate_db.py
+++ b/e2e_samples/unstructured_data/scripts/populate_db.py
@@ -16,7 +16,9 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-n", "--name", default="template-1", help="The name of the template to create")
-    parser.add_argument("-c", "--creator", default="llm-citation-generator", help="The name of the template to create")
+    parser.add_argument(
+        "-c", "--creator", default="llm-citation-generator", help="The creator of the template and questions"
+    )
     args = parser.parse_args()
     template_name = args.name
     creator = args.creator


### PR DESCRIPTION
# Type of PR
<!-- Removed items that do not match with your change. -->

- Documentation changes
- Code changes

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
We need a way for users to populate the db with the a template and questions prior to running the generator

This adds a script to create a template and questions that currently exist in the repo. The user will need to take the question ids that are generated and add them to the variant yaml files. Documentation on this is in the works

## Does this introduce a breaking change? If yes, details on what can break

## Author pre-publish checklist
<!-- Please check check before publishing PR using "x". Remove a column if it's not applicable. -->
- [ ] Added test to prove my fix is effective or new feature works
- [ ] No PII in logs
- [ ] Made corresponding changes to the documentation

## Validation steps
<!-- Optional. -->
- ...

## Issues Closed or Referenced
<!-- This will automatically close the issue when the PR closes. -->
- Closes #issue_number
<!-- this references the issue but does not close with PR. -->
- References #issue_number
