### PR TITLE
[Fabric E2E Sample] Deploying Fabric pipeline as SP

### DIFF
--- a/e2e_samples/fabric_dataops_sample/docs/known_issues_limitations_and_faqs.md
+++ b/e2e_samples/fabric_dataops_sample/docs/known_issues_limitations_and_faqs.md
@@ -115,12 +115,11 @@ Otherwise, these update can be applied as part of the post-processing step menti
 
 ### Fabric REST APIs limitations
 
-The support for managed identities and service principals is not available in few of the Fabric REST APIs. The most notable APIs (in context of this sample) that do not support managed identities are:
+The support for managed identities and service principals is not available in few of the Fabric REST APIs. The most notable API (in context of this sample) that does not support managed identities is:
 
 - [Git APIs](https://learn.microsoft.com/rest/api/fabric/core/git)
-- [Data pipelines](https://learn.microsoft.com/en-us/rest/api/fabric/datapipeline/items)
 
-To handle this limitation, the sample requires executing the deployment script twice - once with the managed identity or service principal and once with the user's credentials. The Git integration and data pipeline are created using the user's credentials.
+To handle this limitation, the sample requires executing the deployment script twice - once with the managed identity or service principal and once with the user's credentials. The Git integration is performed using user's credentials.
 
 ### Fabric Environment does not recognize change in custom libraries with same file name
 

--- a/e2e_samples/fabric_dataops_sample/infrastructure/terraform/main.tf
+++ b/e2e_samples/fabric_dataops_sample/infrastructure/terraform/main.tf
@@ -233,10 +233,8 @@ module "azure_devops_variable_group_w_keyvault" {
   depends_on = [module.key_vault_secret_001]
 }
 
-# Below modules currently do not support service principal/managed identity execution context.
-# Therefore they are enabled only when using user context (var_use_cli==true).
 module "fabric_data_pipeline" {
-  enable                        = var.use_cli && var.deploy_fabric_items
+  enable                        = var.deploy_fabric_items
   source                        = "./modules/fabric/data_pipeline"
   data_pipeline_name            = local.fabric_main_pipeline_name
   data_pipeline_definition_path = local.main_pipeline_definition_path
@@ -252,6 +250,8 @@ module "fabric_data_pipeline" {
   }
 }
 
+# Below module currently does not support service principal/managed identity execution context.
+# Therefore it is enabled only when using user context (var_use_cli==true).
 module "fabric_workspace_git_integration" {
   enable                  = var.use_cli
   source                  = "./modules/fabric/git_integration"


### PR DESCRIPTION
# Type of PR

- Documentation changes
- Code changes

## Purpose

With the latest update, the Fabric data pipeline is now supporting the SP. This PR is to update the Terraform deployment to use SP instead of user context.

## Does this introduce a breaking change? If yes, details on what can break

No

## Author pre-publish checklist
<!-- Please check check before publishing PR using "x". Remove a column if it's not applicable. -->
- [ ] Added test to prove my fix is effective or new feature works
- [x] No PII in logs
- [x] Made corresponding changes to the documentation

## Validation steps
- Deploy the sample based on the instructions

## Issues Closed or Referenced
- Closes #1177 
