### PR TITLE
Add finer-grained telemetry IDs across the repo

### DIFF
--- a/archive/e2e_samples/dataset_versioning/infra/setup.sh
+++ b/archive/e2e_samples/dataset_versioning/infra/setup.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Set partner ID for telemetry. For usage details, see https://github.com/microsoft/modern-data-warehouse-dataops/blob/main/README.md#data-collection
+export AZURE_HTTP_USER_AGENT="acce1e78-f4d8-403c-a3f8-7a0ac57cc49c"
+
 set -o errexit
 set -o pipefail
 set -o nounset

--- a/archive/e2e_samples/dataset_versioning/infra/terraform/live/dev/main.tf
+++ b/archive/e2e_samples/dataset_versioning/infra/terraform/live/dev/main.tf
@@ -5,6 +5,8 @@ terraform {
 }
 
 provider "azurerm" {
+  # Set partner ID for telemetry. For usage details, see https://github.com/microsoft/modern-data-warehouse-dataops/blob/main/README.md#data-collection
+  partner_id                 = "acce1e78-f4d8-403c-a3f8-7a0ac57cc49c"
   skip_provider_registration = true
   features {}
 }

--- a/archive/e2e_samples/parking_sensors_synapse/deploy.sh
+++ b/archive/e2e_samples/parking_sensors_synapse/deploy.sh
@@ -16,6 +16,9 @@
 # CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 # DEALINGS IN THE SOFTWARE.
 
+# Set partner ID for telemetry. For usage details, see https://github.com/microsoft/modern-data-warehouse-dataops/blob/main/README.md#data-collection
+export AZURE_HTTP_USER_AGENT="acce1e78-f4d8-403c-a3f8-7a0ac57cc49c"
+
 set -o errexit
 set -o pipefail
 set -o nounset

--- a/archive/e2e_samples/parking_sensors_synapse/infrastructure/main.bicep
+++ b/archive/e2e_samples/parking_sensors_synapse/infrastructure/main.bicep
@@ -1,3 +1,16 @@
+/* Partner attribution resource for telemetry. For usage details, see https://github.com/microsoft/modern-data-warehouse-dataops/blob/main/README.md#data-collection */
+resource attribution 'Microsoft.Resources/deployments@2020-06-01' = {
+  name: 'pid-acce1e78-f4d8-403c-a3f8-7a0ac57cc49c'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+    }
+  }
+}
+
 param project string = 'mdwdo'
 param env string = 'dev'
 param location string = resourceGroup().location

--- a/archive/e2e_samples/temperature_events/infra/setup.sh
+++ b/archive/e2e_samples/temperature_events/infra/setup.sh
@@ -16,6 +16,9 @@
 # CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 # DEALINGS IN THE SOFTWARE.
 
+# Set partner ID for telemetry. For usage details, see https://github.com/microsoft/modern-data-warehouse-dataops/blob/main/README.md#data-collection
+export AZURE_HTTP_USER_AGENT="acce1e78-f4d8-403c-a3f8-7a0ac57cc49c"
+
 set -o errexit
 set -o pipefail
 set -o nounset

--- a/archive/e2e_samples/temperature_events/infra/terraform/live/dev/main.tf
+++ b/archive/e2e_samples/temperature_events/infra/terraform/live/dev/main.tf
@@ -5,6 +5,8 @@ terraform {
 }
 
 provider "azurerm" {
+  # Set partner ID for telemetry. For usage details, see https://github.com/microsoft/modern-data-warehouse-dataops/blob/main/README.md#data-collection
+  partner_id = "acce1e78-f4d8-403c-a3f8-7a0ac57cc49c"
   features {}
 }
 

--- a/archive/single_tech_samples/databricks_all_in_one/main.bicep
+++ b/archive/single_tech_samples/databricks_all_in_one/main.bicep
@@ -1,5 +1,19 @@
 targetScope = 'subscription'
 
+/* Partner attribution resource for telemetry. For usage details, see https://github.com/microsoft/modern-data-warehouse-dataops/blob/main/README.md#data-collection */
+resource attribution 'Microsoft.Resources/deployments@2020-06-01' = {
+  name: 'pid-acce1e78-f4d8-403c-a3f8-7a0ac57cc49c'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+    }
+  }
+  scope: resourceGroup(resourceGroupName)
+}
+
 @minLength(2)
 @maxLength(4)
 @description('2-4 chars to prefix the Azure resources, NOTE: no number or symbols')

--- a/archive/single_tech_samples/databricks_terraform/Infra/modules/adb-unity-catalog/providers.tf
+++ b/archive/single_tech_samples/databricks_terraform/Infra/modules/adb-unity-catalog/providers.tf
@@ -10,6 +10,8 @@ terraform {
 }
 
 provider "azurerm" {
+  # Set partner ID for telemetry. For usage details, see https://github.com/microsoft/modern-data-warehouse-dataops/blob/main/README.md#data-collection
+  partner_id      = "acce1e78-babd-6b30-049f-9496f0518a8f"
   subscription_id = var.subscription_id
   features {}
 }

--- a/archive/single_tech_samples/databricks_terraform/Infra/modules/adb-workspace/providers.tf
+++ b/archive/single_tech_samples/databricks_terraform/Infra/modules/adb-workspace/providers.tf
@@ -10,6 +10,8 @@ terraform {
 }
 
 provider "azurerm" {
+  # Set partner ID for telemetry. For usage details, see https://github.com/microsoft/modern-data-warehouse-dataops/blob/main/README.md#data-collection
+  partner_id                 = "acce1e78-babd-6b30-049f-9496f0518a8f"
   features {}
   subscription_id            =  var.subscription_id
 }

--- a/archive/single_tech_samples/databricks_terraform/Infra/modules/metastore-and-users/provider.tf
+++ b/archive/single_tech_samples/databricks_terraform/Infra/modules/metastore-and-users/provider.tf
@@ -10,7 +10,9 @@ terraform {
 }
 
 provider "azurerm" {
-  subscription_id = var.subscription_id
+  # Set partner ID for telemetry. For usage details, see https://github.com/microsoft/modern-data-warehouse-dataops/blob/main/README.md#data-collection
+  partner_id          = "acce1e78-babd-6b30-049f-9496f0518a8f"
+  subscription_id     = var.subscription_id
   features {}
   storage_use_azuread = true
 }

--- a/archive/single_tech_samples/storage_lifecycle_management/sample1_data_lifecycle/terraform/main.tf
+++ b/archive/single_tech_samples/storage_lifecycle_management/sample1_data_lifecycle/terraform/main.tf
@@ -13,6 +13,8 @@ terraform {
 }
 
 provider "azurerm" {
+  # Set partner ID for telemetry. For usage details, see https://github.com/microsoft/modern-data-warehouse-dataops/blob/main/README.md#data-collection
+  partner_id = "acce1e78-f4d8-403c-a3f8-7a0ac57cc49c"
   # Configuration options
   features {}
 }

--- a/archive/single_tech_samples/synapse_serverless/infrastructure/main.bicep
+++ b/archive/single_tech_samples/synapse_serverless/infrastructure/main.bicep
@@ -1,3 +1,16 @@
+/* Partner attribution resource for telemetry. For usage details, see https://github.com/microsoft/modern-data-warehouse-dataops/blob/main/README.md#data-collection */
+resource attribution 'Microsoft.Resources/deployments@2020-06-01' = {
+  name: 'pid-acce1e78-f4d8-403c-a3f8-7a0ac57cc49c'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+    }
+  }
+}
+
 param project string = 'sintech'
 param location string = resourceGroup().location
 param deployment_id string

--- a/azuredatafactory/adf_cicd_auto_publish/scripts/deploy_azdo_service_connections_azure.sh
+++ b/azuredatafactory/adf_cicd_auto_publish/scripts/deploy_azdo_service_connections_azure.sh
@@ -26,6 +26,9 @@
 # - Correct Azure DevOps Project selected
 #######################################################
 
+# Set partner ID for telemetry. For usage details, see https://github.com/microsoft/modern-data-warehouse-dataops/blob/main/README.md#data-collection
+export AZURE_HTTP_USER_AGENT="acce1e78-7e8a-0a7e-9676-89d4b312fefe"
+
 set -o errexit
 set -o pipefail
 set -o nounset

--- a/azuredatafactory/adf_cicd_auto_publish/scripts/deploy_infra.sh
+++ b/azuredatafactory/adf_cicd_auto_publish/scripts/deploy_infra.sh
@@ -25,6 +25,9 @@
 # - Correct Azure subscription is selected
 #######################################################
 
+# Set partner ID for telemetry. For usage details, see https://github.com/microsoft/modern-data-warehouse-dataops/blob/main/README.md#data-collection
+export AZURE_HTTP_USER_AGENT="acce1e78-7e8a-0a7e-9676-89d4b312fefe"
+
 set -o errexit
 set -o pipefail
 set -o nounset

--- a/azuredatafactory/adf_data_pre_processing_with_azure_batch/deploy/terraform/provider.tf
+++ b/azuredatafactory/adf_data_pre_processing_with_azure_batch/deploy/terraform/provider.tf
@@ -9,6 +9,8 @@ terraform {
 
 provider "azurerm" {
   # Configuration options
+  # Set partner ID for telemetry. For usage details, see https://github.com/microsoft/modern-data-warehouse-dataops/blob/main/README.md#data-collection
+  partner_id = "acce1e78-dcd0-37e3-4ff3-1ec1a177be51"
   features {
     key_vault {
       recover_soft_deleted_key_vaults = false

--- a/azuresqldb/azuresql_ci_cd/deploy.sh
+++ b/azuresqldb/azuresql_ci_cd/deploy.sh
@@ -21,6 +21,9 @@
 # See README for prerequisites.
 #######################################################
 
+# Set partner ID for telemetry. For usage details, see https://github.com/microsoft/modern-data-warehouse-dataops/blob/main/README.md#data-collection
+export AZURE_HTTP_USER_AGENT="acce1e78-3980-6307-2645-ee3f72fb4092"
+
 set -o errexit
 set -o pipefail
 # set -o xtrace # For debugging

--- a/databricks/parking_sensors/deploy.sh
+++ b/databricks/parking_sensors/deploy.sh
@@ -16,6 +16,9 @@
 # CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 # DEALINGS IN THE SOFTWARE.
 
+# Set partner ID for telemetry. For usage details, see https://github.com/microsoft/modern-data-warehouse-dataops/blob/main/README.md#data-collection
+export AZURE_HTTP_USER_AGENT="acce1e78-babd-6b30-049f-9496f0518a8f"
+
 set -o errexit
 set -o pipefail
 set -o nounset

--- a/databricks/parking_sensors/infrastructure/main.bicep
+++ b/databricks/parking_sensors/infrastructure/main.bicep
@@ -1,3 +1,16 @@
+/* Partner attribution resource for telemetry. For usage details, see https://github.com/microsoft/modern-data-warehouse-dataops/blob/main/README.md#data-collection */
+resource attribution 'Microsoft.Resources/deployments@2020-06-01' = {
+  name: 'pid-acce1e78-babd-6b30-049f-9496f0518a8f'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+    }
+  }
+}
+
 param project string = 'mdwdo'
 param env string = 'dev'
 param email_id string = 'support@domain.com'

--- a/fabric/fabric_dataops_sample/deploy.sh
+++ b/fabric/fabric_dataops_sample/deploy.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Set partner ID for telemetry. For usage details, see https://github.com/microsoft/modern-data-warehouse-dataops/blob/main/README.md#data-collection
+export AZURE_HTTP_USER_AGENT="acce1e78-fb84-2ec8-240c-c457cfba34ad"
+
 set -o errexit
 set -o pipefail
 set -o nounset

--- a/fabric/fabric_dataops_sample/infrastructure/terraform/providers.tf
+++ b/fabric/fabric_dataops_sample/infrastructure/terraform/providers.tf
@@ -13,6 +13,8 @@ provider "fabric" {
 }
 
 provider "azurerm" {
+  # Set partner ID for telemetry. For usage details, see https://github.com/microsoft/modern-data-warehouse-dataops/blob/main/README.md#data-collection
+  partner_id                      = "acce1e78-fb84-2ec8-240c-c457cfba34ad"
   tenant_id                       = var.tenant_id
   subscription_id                 = var.subscription_id
   client_id                       = var.use_msi || var.use_cli ? null : var.client_id

--- a/fabric/fabric_dataops_sample/infrastructure/terraform/providers.tf
+++ b/fabric/fabric_dataops_sample/infrastructure/terraform/providers.tf
@@ -13,7 +13,7 @@ provider "fabric" {
 }
 
 provider "azurerm" {
-  # Set partner ID for telemetry. For usage details, see https://github.com/microsoft/modern-data-warehouse-dataops/blob/main/README.md#data-collection
+  # Set partner ID for telemetry.  For usage details, see https://github.com/microsoft/modern-data-warehouse-dataops/blob/main/README.md#data-collection
   partner_id                      = "acce1e78-fb84-2ec8-240c-c457cfba34ad"
   tenant_id                       = var.tenant_id
   subscription_id                 = var.subscription_id


### PR DESCRIPTION
# Type of PR

- Code changes

## Purpose

This PR improves granular usage tracking in the repo by adding telemetry IDs to Terraform, Bicep, and az CLI files wherever they can be added. 

## Does this introduce a breaking change? If yes, details on what can break

No, although these changes do affect code throughout the repo, so they should be reviewed carefully.

## Author pre-publish checklist

- [x] No PII in logs

## Validation steps

- Run any sample containing one of the newly-added tracking GUIDs.
- Check internal telemetry reporting to observe the activity.

## Issues Closed or Referenced

- Closes #1237 